### PR TITLE
gds_post_send + gds_rollback_qp

### DIFF
--- a/include/gdsync/core.h
+++ b/include/gdsync/core.h
@@ -87,7 +87,7 @@ int gds_register_peer(struct ibv_context *context, unsigned gpu_id);
  * - this API might have higher overhead than ibv_post_send. 
  * - It is provided for convenience only.
  */
-int gds_post_send(struct gds_qp *qp, struct ibv_send_wr *wr, struct ibv_send_wr **bad_wr);
+int gds_post_send(struct gds_qp *qp, struct ibv_exp_send_wr *wr, struct ibv_exp_send_wr **bad_wr);
 
 /* \brief: CPU-synchronous post recv for peer QPs
  *

--- a/include/gdsync/core.h
+++ b/include/gdsync/core.h
@@ -57,7 +57,6 @@ enum gds_create_qp_flags {
 };
 
 typedef struct ibv_qp_init_attr_ex gds_qp_init_attr_t;
-typedef struct ibv_qp_attr gds_qp_attr_t;
 typedef struct ibv_exp_send_wr gds_send_wr;
 
 struct gds_cq {

--- a/include/gdsync/core.h
+++ b/include/gdsync/core.h
@@ -57,6 +57,7 @@ enum gds_create_qp_flags {
 };
 
 typedef struct ibv_qp_init_attr_ex gds_qp_init_attr_t;
+typedef struct ibv_qp_attr gds_qp_attr_t;
 
 struct gds_cq {
         struct ibv_cq *cq;

--- a/include/gdsync/core.h
+++ b/include/gdsync/core.h
@@ -58,6 +58,7 @@ enum gds_create_qp_flags {
 
 typedef struct ibv_qp_init_attr_ex gds_qp_init_attr_t;
 typedef struct ibv_qp_attr gds_qp_attr_t;
+typedef struct ibv_exp_send_wr gds_send_wr;
 
 struct gds_cq {
         struct ibv_cq *cq;
@@ -87,7 +88,7 @@ int gds_register_peer(struct ibv_context *context, unsigned gpu_id);
  * - this API might have higher overhead than ibv_post_send. 
  * - It is provided for convenience only.
  */
-int gds_post_send(struct gds_qp *qp, struct ibv_exp_send_wr *wr, struct ibv_exp_send_wr **bad_wr);
+int gds_post_send(struct gds_qp *qp, gds_send_wr *wr, gds_send_wr **bad_wr);
 
 /* \brief: CPU-synchronous post recv for peer QPs
  *
@@ -112,9 +113,9 @@ int gds_stream_wait_cq_ex(CUstream stream, struct gds_cq *cq, int flags, uint32_
  * Notes:
  * - execution of the send operation happens in CUDA stream order
  */
-int gds_stream_queue_send(CUstream stream, struct gds_qp *qp, struct ibv_exp_send_wr *p_ewr, struct ibv_exp_send_wr **bad_ewr);
+int gds_stream_queue_send(CUstream stream, struct gds_qp *qp, gds_send_wr *p_ewr, gds_send_wr **bad_ewr);
 // same as above, plus writing a trailing flag word efficiently
-int gds_stream_queue_send_ex(CUstream stream, struct gds_qp *qp, struct ibv_exp_send_wr *p_ewr, struct ibv_exp_send_wr **bad_ewr, uint32_t *dw, uint32_t val);
+int gds_stream_queue_send_ex(CUstream stream, struct gds_qp *qp, gds_send_wr *p_ewr, gds_send_wr **bad_ewr, uint32_t *dw, uint32_t val);
 
 /* \brief GPU stream-synchronous post recv
  * Notes:
@@ -162,7 +163,7 @@ typedef struct gds_descriptor {
 int gds_prepare_wait_value32(uint32_t *ptr, uint32_t value, int cond_flags, int flags, gds_value32_descriptor_t *desc);
 int gds_stream_post_descriptors(CUstream stream, size_t n_descs, gds_descriptor_t *descs);
 
-int gds_prepare_send(struct gds_qp *qp, struct ibv_exp_send_wr *p_ewr, struct ibv_exp_send_wr **bad_ewr, gds_send_request_t *request);
+int gds_prepare_send(struct gds_qp *qp, gds_send_wr *p_ewr, gds_send_wr **bad_ewr, gds_send_request_t *request);
 int gds_stream_post_send(CUstream stream, gds_send_request_t *request);
 int gds_stream_post_send_ex(CUstream stream, gds_send_request_t *request, uint32_t *dw, uint32_t val);
 int gds_stream_post_send_all(CUstream stream, int count, gds_send_request_t *request);

--- a/include/gdsync/core.h
+++ b/include/gdsync/core.h
@@ -32,7 +32,7 @@
 #error "don't include directly this header, use gdsync.h always"
 #endif
 
-#define GDS_API_MAJOR_VERSION    1U
+#define GDS_API_MAJOR_VERSION    2U
 #define GDS_API_MINOR_VERSION    1U
 #define GDS_API_VERSION          ((GDS_API_MAJOR_VERSION << 16) | GDS_API_MINOR_VERSION)
 #define GDS_API_VERSION_COMPATIBLE(v) \

--- a/src/apis.cpp
+++ b/src/apis.cpp
@@ -210,6 +210,7 @@ int gds_stream_queue_send_ex(CUstream stream, struct gds_qp *qp, struct ibv_exp_
 
         ret = gds_post_pokes(stream, 1, &send_info, dw, val);
         if (ret) {
+            gds_err("error %d in gds_post_pokes\n", ret);
             //the request has been committed here
             gds_rollback_qp(qp, &send_info, IBV_EXP_ROLLBACK_ABORT_LATE);
             goto out;

--- a/src/apis.cpp
+++ b/src/apis.cpp
@@ -119,7 +119,7 @@ out:
     return ret;
 }
 
-int gds_post_send(struct gds_qp *qp, struct ibv_exp_send_wr *p_ewr, struct ibv_exp_send_wr **bad_ewr)
+int gds_post_send(struct gds_qp *qp, gds_send_wr *p_ewr, gds_send_wr **bad_ewr)
 {
     int ret = 0, ret2=0;
     gds_send_request_t send_info;
@@ -165,8 +165,8 @@ out:
 
 //-----------------------------------------------------------------------------
 
-int gds_prepare_send(struct gds_qp *qp, struct ibv_exp_send_wr *p_ewr, 
-                     struct ibv_exp_send_wr **bad_ewr, 
+int gds_prepare_send(struct gds_qp *qp, gds_send_wr *p_ewr, 
+                     gds_send_wr **bad_ewr, 
                      gds_send_request_t *request)
 {
         int ret = 0;
@@ -189,8 +189,6 @@ int gds_prepare_send(struct gds_qp *qp, struct ibv_exp_send_wr *p_ewr,
         ret = ibv_exp_peer_commit_qp(qp->qp, &request->commit);
         if (ret) {
                 gds_err("error %d in ibv_exp_peer_commit_qp\n", ret);
-                //request not commited in case of error
-                
                 //gds_wait_kernel();
                 goto out;
         }
@@ -200,7 +198,7 @@ out:
 
 //-----------------------------------------------------------------------------
 
-int gds_stream_queue_send_ex(CUstream stream, struct gds_qp *qp, struct ibv_exp_send_wr *p_ewr, struct ibv_exp_send_wr **bad_ewr, uint32_t *dw, uint32_t val)
+int gds_stream_queue_send_ex(CUstream stream, struct gds_qp *qp, gds_send_wr *p_ewr, gds_send_wr **bad_ewr, uint32_t *dw, uint32_t val)
 {
     int ret = 0, ret2=0;
 	gds_send_request_t send_info;
@@ -225,7 +223,7 @@ out:
 
 //-----------------------------------------------------------------------------
 
-int gds_stream_queue_send(CUstream stream, struct gds_qp *qp, struct ibv_exp_send_wr *p_ewr, struct ibv_exp_send_wr **bad_ewr)
+int gds_stream_queue_send(CUstream stream, struct gds_qp *qp, gds_send_wr *p_ewr, gds_send_wr **bad_ewr)
 {
         return gds_stream_queue_send_ex(stream, qp, p_ewr, bad_ewr, NULL, 0);
 }

--- a/src/apis.cpp
+++ b/src/apis.cpp
@@ -109,7 +109,7 @@ int gds_rollback_qp(struct gds_qp *qp, gds_send_request_t * send_info, int flags
     rollback.flags = flags;
     /* Reserved for future expensions, must be 0 */
     rollback.comp_mask = 0;
-    
+    gds_warn("Need to rollback WQE %x\n", rollback.rollback_id);
     ret = ibv_exp_rollback_qp(qp->qp, &rollback);
     if(ret)
     {

--- a/src/apis.cpp
+++ b/src/apis.cpp
@@ -210,7 +210,9 @@ int gds_stream_queue_send_ex(CUstream stream, struct gds_qp *qp, struct ibv_exp_
 
         ret = gds_post_pokes(stream, 1, &send_info, dw, val);
         if (ret) {
-                goto out;
+            //the request has been committed here
+            gds_rollback_qp(qp, &send_info, IBV_EXP_ROLLBACK_ABORT_LATE);
+            goto out;
         }
 out:
         return ret;

--- a/src/apis.cpp
+++ b/src/apis.cpp
@@ -54,380 +54,380 @@
 
 static void gds_init_ops(struct peer_op_wr *op, int count)
 {
-	int i = count;
-	while (--i)
-		op[i-1].next = &op[i];
-	op[count-1].next = NULL;
+        int i = count;
+        while (--i)
+                op[i-1].next = &op[i];
+        op[count-1].next = NULL;
 }
 
 //-----------------------------------------------------------------------------
 
 static void gds_init_send_info(gds_send_request_t *info)
 {
-	gds_dbg("send_request=%p\n", info);
-	memset(info, 0, sizeof(*info));
+        gds_dbg("send_request=%p\n", info);
+        memset(info, 0, sizeof(*info));
 
-	info->commit.storage = info->wr;
-	info->commit.entries = sizeof(info->wr)/sizeof(info->wr[0]);
-	gds_init_ops(info->commit.storage, info->commit.entries);
+        info->commit.storage = info->wr;
+        info->commit.entries = sizeof(info->wr)/sizeof(info->wr[0]);
+        gds_init_ops(info->commit.storage, info->commit.entries);
 }
 
 //-----------------------------------------------------------------------------
 
 static void gds_init_wait_request(gds_wait_request_t *request, uint32_t offset)
 {
-	gds_dbg("wait_request=%p offset=%08x\n", request, offset);
-	memset(request, 0, sizeof(*request));
-	request->peek.storage = request->wr;
-	request->peek.entries = sizeof(request->wr)/sizeof(request->wr[0]);
-	request->peek.whence = IBV_EXP_PEER_PEEK_ABSOLUTE;
-	request->peek.offset = offset;
-	gds_init_ops(request->peek.storage, request->peek.entries);
+        gds_dbg("wait_request=%p offset=%08x\n", request, offset);
+        memset(request, 0, sizeof(*request));
+        request->peek.storage = request->wr;
+        request->peek.entries = sizeof(request->wr)/sizeof(request->wr[0]);
+        request->peek.whence = IBV_EXP_PEER_PEEK_ABSOLUTE;
+        request->peek.offset = offset;
+        gds_init_ops(request->peek.storage, request->peek.entries);
 }
 
 //-----------------------------------------------------------------------------
 static int gds_rollback_qp(struct gds_qp *qp, gds_send_request_t * send_info, enum ibv_exp_rollback_flags flag)
 {
-	struct ibv_exp_rollback_ctx rollback;
-	int ret=0;
+        struct ibv_exp_rollback_ctx rollback;
+        int ret=0;
 
-	assert(qp);
-	assert(qp->qp);
-	assert(send_info);
-	if(
-			flag != IBV_EXP_ROLLBACK_ABORT_UNCOMMITED && 
-			flag != IBV_EXP_ROLLBACK_ABORT_LATE
-	  )
-	{
-		gds_err("erroneous ibv_exp_rollback_flags flag input value\n");
-		ret=1;
-		goto out;
-	} 
+        assert(qp);
+        assert(qp->qp);
+        assert(send_info);
+        if(
+                        flag != IBV_EXP_ROLLBACK_ABORT_UNCOMMITED && 
+                        flag != IBV_EXP_ROLLBACK_ABORT_LATE
+          )
+        {
+                gds_err("erroneous ibv_exp_rollback_flags flag input value\n");
+                ret=1;
+                goto out;
+        } 
 
-	/* from ibv_exp_peer_commit call */
-	rollback.rollback_id = send_info->commit.rollback_id;
-	/* from ibv_exp_rollback_flag */
-	rollback.flags = flag;
-	/* Reserved for future expensions, must be 0 */
-	rollback.comp_mask = 0;
-	gds_warn("Need to rollback WQE %x\n", rollback.rollback_id);
-	ret = ibv_exp_rollback_qp(qp->qp, &rollback);
-	if(ret)
-		gds_err("error %d in ibv_exp_rollback_qp\n", ret);
+        /* from ibv_exp_peer_commit call */
+        rollback.rollback_id = send_info->commit.rollback_id;
+        /* from ibv_exp_rollback_flag */
+        rollback.flags = flag;
+        /* Reserved for future expensions, must be 0 */
+        rollback.comp_mask = 0;
+        gds_warn("Need to rollback WQE %x\n", rollback.rollback_id);
+        ret = ibv_exp_rollback_qp(qp->qp, &rollback);
+        if(ret)
+                gds_err("error %d in ibv_exp_rollback_qp\n", ret);
 
 out:
-	return ret;
+        return ret;
 }
 
 int gds_post_send(struct gds_qp *qp, gds_send_wr *p_ewr, gds_send_wr **bad_ewr)
 {
-	int ret = 0, ret2=0;
-	gds_send_request_t send_info;
-	ret = gds_prepare_send(qp, p_ewr, bad_ewr, &send_info);
-	if (ret) {
-		gds_err("error %d in gds_prepare_send\n", ret);
-		goto out;
-	}
+        int ret = 0, ret2=0;
+        gds_send_request_t send_info;
+        ret = gds_prepare_send(qp, p_ewr, bad_ewr, &send_info);
+        if (ret) {
+                gds_err("error %d in gds_prepare_send\n", ret);
+                goto out;
+        }
 
-	ret = gds_post_pokes_on_cpu(1, &send_info, NULL, 0);
-	if (ret) {
-		gds_err("error %d in gds_post_pokes_on_cpu\n", ret);
-		ret2 = gds_rollback_qp(qp, &send_info, IBV_EXP_ROLLBACK_ABORT_LATE);
-		if (ret2) {
-			gds_err("error %d in gds_rollback_qp\n", ret2);
-		}
+        ret = gds_post_pokes_on_cpu(1, &send_info, NULL, 0);
+        if (ret) {
+                gds_err("error %d in gds_post_pokes_on_cpu\n", ret);
+                ret2 = gds_rollback_qp(qp, &send_info, IBV_EXP_ROLLBACK_ABORT_LATE);
+                if (ret2) {
+                        gds_err("error %d in gds_rollback_qp\n", ret2);
+                }
 
-		goto out;
-	}
+                goto out;
+        }
 
 out:
-	return ret;
+        return ret;
 }
 
 //-----------------------------------------------------------------------------
 
 int gds_post_recv(struct gds_qp *qp, struct ibv_recv_wr *wr, struct ibv_recv_wr **bad_wr)
 {
-	int ret = 0;
+        int ret = 0;
 
-	gds_dbg("qp=%p wr=%p\n", qp, wr);
-	assert(qp);
-	assert(qp->qp);
-	ret = ibv_post_recv(qp->qp, wr, bad_wr);
-	if (ret) {
-		gds_err("error %d in ibv_post_recv\n", ret);
-		goto out;
-	}
+        gds_dbg("qp=%p wr=%p\n", qp, wr);
+        assert(qp);
+        assert(qp->qp);
+        ret = ibv_post_recv(qp->qp, wr, bad_wr);
+        if (ret) {
+                gds_err("error %d in ibv_post_recv\n", ret);
+                goto out;
+        }
 
 out:
-	return ret;
+        return ret;
 }
 
 //-----------------------------------------------------------------------------
 
 int gds_prepare_send(struct gds_qp *qp, gds_send_wr *p_ewr, 
-		gds_send_wr **bad_ewr, 
-		gds_send_request_t *request)
+                gds_send_wr **bad_ewr, 
+                gds_send_request_t *request)
 {
-	int ret = 0;
-	gds_init_send_info(request);
-	assert(qp);
-	assert(qp->qp);
-	ret = ibv_exp_post_send(qp->qp, p_ewr, bad_ewr);
-	if (ret) {
+        int ret = 0;
+        gds_init_send_info(request);
+        assert(qp);
+        assert(qp->qp);
+        ret = ibv_exp_post_send(qp->qp, p_ewr, bad_ewr);
+        if (ret) {
 
-		if (ret == ENOMEM) {
-			// out of space error can happen too often to report
-			gds_dbg("ENOMEM error %d in ibv_exp_post_send\n", ret);
-		} else {
-			gds_err("error %d in ibv_exp_post_send\n", ret);
-			//request not commited yet!
-		}
-		goto out;
-	}
+                if (ret == ENOMEM) {
+                        // out of space error can happen too often to report
+                        gds_dbg("ENOMEM error %d in ibv_exp_post_send\n", ret);
+                } else {
+                        gds_err("error %d in ibv_exp_post_send\n", ret);
+                        //request not commited yet!
+                }
+                goto out;
+        }
 
-	ret = ibv_exp_peer_commit_qp(qp->qp, &request->commit);
-	if (ret) {
-		gds_err("error %d in ibv_exp_peer_commit_qp\n", ret);
-		//gds_wait_kernel();
-		goto out;
-	}
+        ret = ibv_exp_peer_commit_qp(qp->qp, &request->commit);
+        if (ret) {
+                gds_err("error %d in ibv_exp_peer_commit_qp\n", ret);
+                //gds_wait_kernel();
+                goto out;
+        }
 out:
-	return ret;
+        return ret;
 }
 
 //-----------------------------------------------------------------------------
 
 int gds_stream_queue_send_ex(CUstream stream, struct gds_qp *qp, gds_send_wr *p_ewr, gds_send_wr **bad_ewr, uint32_t *dw, uint32_t val)
 {
-	int ret = 0, ret2=0;
-	gds_send_request_t send_info;
+        int ret = 0, ret2=0;
+        gds_send_request_t send_info;
 
-	ret = gds_prepare_send(qp, p_ewr, bad_ewr, &send_info);
-	if (ret) {
-		goto out;
-	}
+        ret = gds_prepare_send(qp, p_ewr, bad_ewr, &send_info);
+        if (ret) {
+                goto out;
+        }
 
-	ret = gds_post_pokes(stream, 1, &send_info, dw, val);
-	if (ret) {
-		gds_err("error %d in gds_post_pokes\n", ret);
-		ret2 = gds_rollback_qp(qp, &send_info, IBV_EXP_ROLLBACK_ABORT_LATE);
-		if (ret2) {
-			gds_err("error %d in gds_rollback_qp\n", ret2);
-		}
-		goto out;
-	}
+        ret = gds_post_pokes(stream, 1, &send_info, dw, val);
+        if (ret) {
+                gds_err("error %d in gds_post_pokes\n", ret);
+                ret2 = gds_rollback_qp(qp, &send_info, IBV_EXP_ROLLBACK_ABORT_LATE);
+                if (ret2) {
+                        gds_err("error %d in gds_rollback_qp\n", ret2);
+                }
+                goto out;
+        }
 out:
-	return ret;
+        return ret;
 }
 
 //-----------------------------------------------------------------------------
 
 int gds_stream_queue_send(CUstream stream, struct gds_qp *qp, gds_send_wr *p_ewr, gds_send_wr **bad_ewr)
 {
-	return gds_stream_queue_send_ex(stream, qp, p_ewr, bad_ewr, NULL, 0);
+        return gds_stream_queue_send_ex(stream, qp, p_ewr, bad_ewr, NULL, 0);
 }
 
 //-----------------------------------------------------------------------------
 
 int gds_stream_post_send(CUstream stream, gds_send_request_t *request)
 {
-	int ret = 0;
-	//struct ibv_exp_send_ex_info *info = (struct ibv_exp_send_ex_info *) request;
-	ret = gds_post_pokes(stream, 1, request, NULL, 0);
-	if (ret) {
-		gds_err("gds_post_pokes (%d)\n", ret);
-	}
-	return ret;
+        int ret = 0;
+        //struct ibv_exp_send_ex_info *info = (struct ibv_exp_send_ex_info *) request;
+        ret = gds_post_pokes(stream, 1, request, NULL, 0);
+        if (ret) {
+                gds_err("gds_post_pokes (%d)\n", ret);
+        }
+        return ret;
 }
 
 //-----------------------------------------------------------------------------
 
 int gds_stream_post_send_all(CUstream stream, int count, gds_send_request_t *request)
 {
-	int ret = 0;
+        int ret = 0;
 
-	//struct ibv_exp_send_ex_info *info = (struct ibv_exp_send_ex_info *) request;
+        //struct ibv_exp_send_ex_info *info = (struct ibv_exp_send_ex_info *) request;
 
-	ret = gds_post_pokes(stream, count, request, NULL, 0);
-	if (ret) {
-		gds_err("error in gds_post_pokes (%d)\n", ret);
-	}
-	return ret;
+        ret = gds_post_pokes(stream, count, request, NULL, 0);
+        if (ret) {
+                gds_err("error in gds_post_pokes (%d)\n", ret);
+        }
+        return ret;
 }
 
 //-----------------------------------------------------------------------------
 
 int gds_stream_post_send_ex(CUstream stream, gds_send_request_t *request, uint32_t *dw, uint32_t val)
 {
-	int ret = 0;
+        int ret = 0;
 
-	//struct ibv_exp_send_ex_info *info = (struct ibv_exp_send_ex_info *) request;
+        //struct ibv_exp_send_ex_info *info = (struct ibv_exp_send_ex_info *) request;
 
-	ret = gds_post_pokes(stream, 1, request, dw, val);
-	if (ret) {
-		gds_err("error in gds_post_pokes (%d)\n", ret);
-	}
-	return ret;
+        ret = gds_post_pokes(stream, 1, request, dw, val);
+        if (ret) {
+                gds_err("error in gds_post_pokes (%d)\n", ret);
+        }
+        return ret;
 }
 
 //-----------------------------------------------------------------------------
 
 int gds_stream_queue_recv(CUstream stream, struct gds_qp *qp, struct ibv_recv_wr *p_ewr, struct ibv_recv_wr **bad_ewr)
 {
-	int ret = 0;
+        int ret = 0;
 #if 0
-	struct ibv_exp_recv_ex_info send_info;
-	gds_dbg("calling gds_stream_queue_recv()\n");
-	ret = ibv_exp_post_recv_ex(qp, p_ewr, bad_ewr, &recv_info);
-	if (ret) {
-		gds_err("ibv_exp_post_recv_ex (%d)\n", ret);
-		//gds_wait_kernel();
-		return ret;
-	}
-	ret = gds_post_pokes(stream, &send_info);
+        struct ibv_exp_recv_ex_info send_info;
+        gds_dbg("calling gds_stream_queue_recv()\n");
+        ret = ibv_exp_post_recv_ex(qp, p_ewr, bad_ewr, &recv_info);
+        if (ret) {
+                gds_err("ibv_exp_post_recv_ex (%d)\n", ret);
+                //gds_wait_kernel();
+                return ret;
+        }
+        ret = gds_post_pokes(stream, &send_info);
 #else
-	gds_err("queue_recv not implemented\n");
-	ret = EINVAL;
+        gds_err("queue_recv not implemented\n");
+        ret = EINVAL;
 #endif
-	return ret;
+        return ret;
 }
 
 //-----------------------------------------------------------------------------
 
 int gds_prepare_wait_cq(struct gds_cq *cq, gds_wait_request_t *request, int flags)
 {
-	int retcode = 0;
+        int retcode = 0;
 
-	gds_init_wait_request(request, cq->curr_offset++);
+        gds_init_wait_request(request, cq->curr_offset++);
 
-	retcode = ibv_exp_peer_peek_cq(cq->cq, &request->peek);
-	if (retcode == -ENOSPC) {
-		// TODO: handle too few entries
-		gds_err("not enough ops in peer_peek_cq\n");
-		goto out;
-	} else if (retcode) {
-		gds_err("error %d in peer_peek_cq\n", retcode);
-		goto out;
-	}
-	//gds_dump_wait_request(request, 1);
+        retcode = ibv_exp_peer_peek_cq(cq->cq, &request->peek);
+        if (retcode == -ENOSPC) {
+                // TODO: handle too few entries
+                gds_err("not enough ops in peer_peek_cq\n");
+                goto out;
+        } else if (retcode) {
+                gds_err("error %d in peer_peek_cq\n", retcode);
+                goto out;
+        }
+        //gds_dump_wait_request(request, 1);
 out:
 
-	return retcode;
+        return retcode;
 }
 
 //-----------------------------------------------------------------------------
 
 int gds_append_wait_cq(gds_wait_request_t *request, uint32_t *dw, uint32_t val)
 {
-	int ret = 0;
-	unsigned MAX_NUM_ENTRIES = sizeof(request->wr)/sizeof(request->wr[0]);
-	unsigned n = request->peek.entries;
-	struct peer_op_wr *wr = request->peek.storage;
+        int ret = 0;
+        unsigned MAX_NUM_ENTRIES = sizeof(request->wr)/sizeof(request->wr[0]);
+        unsigned n = request->peek.entries;
+        struct peer_op_wr *wr = request->peek.storage;
 
-	if (n + 1 > MAX_NUM_ENTRIES) {
-		gds_err("no space left to stuff a poke\n");
-		ret = EINVAL;
-		goto out;
-	}
+        if (n + 1 > MAX_NUM_ENTRIES) {
+                gds_err("no space left to stuff a poke\n");
+                ret = EINVAL;
+                goto out;
+        }
 
-	// at least 1 op
-	assert(n);
-	assert(wr);
+        // at least 1 op
+        assert(n);
+        assert(wr);
 
-	for (; n; --n) wr = wr->next;
-	assert(wr);
+        for (; n; --n) wr = wr->next;
+        assert(wr);
 
-	wr->type = IBV_EXP_PEER_OP_STORE_DWORD;
-	wr->wr.dword_va.data = val;
-	wr->wr.dword_va.target_id = 0; // direct mapping, offset IS the address
-	wr->wr.dword_va.offset = (ptrdiff_t)(dw-(uint32_t*)0);
+        wr->type = IBV_EXP_PEER_OP_STORE_DWORD;
+        wr->wr.dword_va.data = val;
+        wr->wr.dword_va.target_id = 0; // direct mapping, offset IS the address
+        wr->wr.dword_va.offset = (ptrdiff_t)(dw-(uint32_t*)0);
 
-	++request->peek.entries;
+        ++request->peek.entries;
 
 out:
-	return ret;
+        return ret;
 }
 
 //-----------------------------------------------------------------------------
 
 int gds_stream_post_wait_cq(CUstream stream, gds_wait_request_t *request)
 {
-	return gds_stream_post_wait_cq_multi(stream, 1, request, NULL, 0);
+        return gds_stream_post_wait_cq_multi(stream, 1, request, NULL, 0);
 }
 
 //-----------------------------------------------------------------------------
 
 int gds_stream_post_wait_cq_ex(CUstream stream, gds_wait_request_t *request, uint32_t *dw, uint32_t val)
 {
-	return gds_stream_post_wait_cq_multi(stream, 1, request, dw, val);
+        return gds_stream_post_wait_cq_multi(stream, 1, request, dw, val);
 }
 
 //-----------------------------------------------------------------------------
 
 int gds_stream_post_wait_cq_all(CUstream stream, int count, gds_wait_request_t *requests)
 {
-	return gds_stream_post_wait_cq_multi(stream, count, requests, NULL, 0);
+        return gds_stream_post_wait_cq_multi(stream, count, requests, NULL, 0);
 }
 
 //-----------------------------------------------------------------------------
 
 int gds_stream_wait_cq_ex(CUstream stream, struct gds_cq *cq, int flag, uint32_t *dw, uint32_t val)
 {
-	int retcode = 0;
-	int ret;
-	gds_wait_request_t request;
+        int retcode = 0;
+        int ret;
+        gds_wait_request_t request;
 
-	assert(cq);
-	assert(stream);
+        assert(cq);
+        assert(stream);
 
-	ret = gds_prepare_wait_cq(cq, &request, flag);
-	if (ret) {
-		gds_err("error %d in gds_prepare_wait_cq\n", ret);
-		goto out;
-	}
+        ret = gds_prepare_wait_cq(cq, &request, flag);
+        if (ret) {
+                gds_err("error %d in gds_prepare_wait_cq\n", ret);
+                goto out;
+        }
 
-	ret = gds_stream_post_wait_cq_ex(stream, &request, dw, val);
-	if (ret) {
-		gds_err("error %d in gds_stream_post_wait_cq_ex\n", ret);
-		retcode = ret;
-		goto out;
-	}
+        ret = gds_stream_post_wait_cq_ex(stream, &request, dw, val);
+        if (ret) {
+                gds_err("error %d in gds_stream_post_wait_cq_ex\n", ret);
+                retcode = ret;
+                goto out;
+        }
 
 out:
-	return retcode;
+        return retcode;
 }
 
 //-----------------------------------------------------------------------------
 
 int gds_stream_wait_cq(CUstream stream, struct gds_cq *cq, int flags)
 {
-	return gds_stream_wait_cq_ex(stream, cq, flags, NULL, 0);
+        return gds_stream_wait_cq_ex(stream, cq, flags, NULL, 0);
 }
 
 //-----------------------------------------------------------------------------
 
 int gds_post_wait_cq(struct gds_cq *cq, gds_wait_request_t *request, int flags)
 {
-	assert(cq);
-	assert(request);
-	struct ibv_exp_peer_abort_peek abort_ctx;
-	abort_ctx.peek_id = request->peek.peek_id;
-	abort_ctx.comp_mask = 0;
-	return ibv_exp_peer_abort_peek_cq(cq->cq, &abort_ctx);
+        assert(cq);
+        assert(request);
+        struct ibv_exp_peer_abort_peek abort_ctx;
+        abort_ctx.peek_id = request->peek.peek_id;
+        abort_ctx.comp_mask = 0;
+        return ibv_exp_peer_abort_peek_cq(cq->cq, &abort_ctx);
 }
 
 //-----------------------------------------------------------------------------
 
 int gds_prepare_wait_value32(uint32_t *ptr, uint32_t value, int cond_flags, int flags, gds_value32_descriptor_t *desc)
 {
-	int ret = 0;
-	assert(desc);
-	desc->ptr = ptr;
-	desc->value = value;
-	desc->flags = flags;
-	desc->cond_flags = cond_flags;
-	return ret;
+        int ret = 0;
+        assert(desc);
+        desc->ptr = ptr;
+        desc->value = value;
+        desc->flags = flags;
+        desc->cond_flags = cond_flags;
+        return ret;
 }
 
 //-----------------------------------------------------------------------------

--- a/tests/gds_kernel_latency.c
+++ b/tests/gds_kernel_latency.c
@@ -441,8 +441,8 @@ static int pp_post_send(struct pingpong_context *ctx, uint32_t qpn)
 		.wr_id	    = PINGPONG_SEND_WRID,
 		.sg_list    = &list,
 		.num_sge    = 1,
-		.opcode     = IBV_WR_SEND,
-		.send_flags = IBV_SEND_SIGNALED,
+		.exp_opcode     = IBV_EXP_WR_SEND,
+		.exp_send_flags = IBV_EXP_SEND_SIGNALED,
 		.wr         = {
 			.ud = {
 				 .ah          = ctx->ah,

--- a/tests/gds_kernel_latency.c
+++ b/tests/gds_kernel_latency.c
@@ -437,7 +437,7 @@ static int pp_post_send(struct pingpong_context *ctx, uint32_t qpn)
 		.length = ctx->size,
 		.lkey	= ctx->mr->lkey
 	};
-	struct ibv_exp_send_wr wr = {
+	gds_send_wr wr = {
 		.wr_id	    = PINGPONG_SEND_WRID,
 		.sg_list    = &list,
 		.num_sge    = 1,
@@ -451,7 +451,7 @@ static int pp_post_send(struct pingpong_context *ctx, uint32_t qpn)
 			 }
 		}
 	};
-	struct ibv_exp_send_wr *bad_wr;
+	gds_send_wr *bad_wr;
     printf("ibv_post_send\n");
     return gds_post_send(ctx->gds_qp, &wr, &bad_wr);
 }
@@ -464,7 +464,7 @@ static int pp_post_gpu_send(struct pingpong_context *ctx, uint32_t qpn)
 		.length = ctx->size,
 		.lkey	= ctx->mr->lkey
 	};
-	struct ibv_exp_send_wr ewr = {
+	gds_send_wr ewr = {
 		.wr_id	    = PINGPONG_SEND_WRID,
 		.sg_list    = &list,
 		.num_sge    = 1,
@@ -479,7 +479,7 @@ static int pp_post_gpu_send(struct pingpong_context *ctx, uint32_t qpn)
 		},
 		.comp_mask = 0
 	};
-	struct ibv_exp_send_wr *bad_ewr;
+	gds_send_wr *bad_ewr;
         //printf("gpu_post_send_on_stream\n");
         return gds_stream_queue_send(gpu_stream, ctx->gds_qp, &ewr, &bad_ewr);
 }

--- a/tests/gds_kernel_latency.c
+++ b/tests/gds_kernel_latency.c
@@ -437,7 +437,7 @@ static int pp_post_send(struct pingpong_context *ctx, uint32_t qpn)
 		.length = ctx->size,
 		.lkey	= ctx->mr->lkey
 	};
-	struct ibv_send_wr wr = {
+	struct ibv_exp_send_wr wr = {
 		.wr_id	    = PINGPONG_SEND_WRID,
 		.sg_list    = &list,
 		.num_sge    = 1,
@@ -451,9 +451,9 @@ static int pp_post_send(struct pingpong_context *ctx, uint32_t qpn)
 			 }
 		}
 	};
-	struct ibv_send_wr *bad_wr;
-        printf("ibv_post_send\n");
-        return gds_post_send(ctx->gds_qp, &wr, &bad_wr);
+	struct ibv_exp_send_wr *bad_wr;
+    printf("ibv_post_send\n");
+    return gds_post_send(ctx->gds_qp, &wr, &bad_wr);
 }
 
 static int pp_post_gpu_send(struct pingpong_context *ctx, uint32_t qpn)

--- a/tests/gds_kernel_latency.c
+++ b/tests/gds_kernel_latency.c
@@ -452,8 +452,7 @@ static int pp_post_send(struct pingpong_context *ctx, uint32_t qpn)
 		}
 	};
 	gds_send_wr *bad_wr;
-    printf("ibv_post_send\n");
-    return gds_post_send(ctx->gds_qp, &wr, &bad_wr);
+	return gds_post_send(ctx->gds_qp, &wr, &bad_wr);
 }
 
 static int pp_post_gpu_send(struct pingpong_context *ctx, uint32_t qpn)

--- a/tests/gds_kernel_loopback_latency.c
+++ b/tests/gds_kernel_loopback_latency.c
@@ -504,7 +504,7 @@ static int pp_post_gpu_send(struct pingpong_context *ctx, uint32_t qpn, CUstream
 		.length = ctx->size,
 		.lkey	= ctx->mr->lkey
 	};
-	struct ibv_exp_send_wr ewr = {
+	gds_send_wr ewr = {
 		.wr_id	    = PINGPONG_SEND_WRID,
 		.sg_list    = &list,
 		.num_sge    = 1,
@@ -519,7 +519,7 @@ static int pp_post_gpu_send(struct pingpong_context *ctx, uint32_t qpn, CUstream
 		},
 		.comp_mask = 0
 	};
-	struct ibv_exp_send_wr *bad_ewr;
+	gds_send_wr *bad_ewr;
         //printf("gpu_post_send_on_stream\n");
         return gds_stream_queue_send(*gpu_stream, ctx->gds_qp, &ewr, &bad_ewr);
 }


### PR DESCRIPTION
Issues #4 and #5 :
- gds_rollback_qp() function introduced to rollback send wqe already commited, in case of error
- gds_rollback_qp() used if gds_post_pokes() or gds_post_pokes_on_cpu() fail
- gds_post_send() now uses the exp version and refers to gds_prepare_send() as gds_stream_queue_send_ex()
- in tests/gds_kernel_latency(), changed data structures in pp_post_send() function