### PR TITLE
implement !peersync case in gds_kernel_loopback_latency via CUDA stream callbacks

### DIFF
--- a/include/gdsync/core.h
+++ b/include/gdsync/core.h
@@ -296,7 +296,7 @@ int gds_stream_post_descriptors(CUstream stream, size_t n_descs, gds_descriptor_
  * - It is provided for convenience only.
  * - It might fail if trying to access CUDA device memory pointers
  */
-int gds_post_descriptors(CUstream stream, size_t n_descs, gds_descriptor_t *descs, int flags);
+int gds_post_descriptors(size_t n_descs, gds_descriptor_t *descs, int flags);
 
 
 /*

--- a/include/gdsync/core.h
+++ b/include/gdsync/core.h
@@ -289,6 +289,16 @@ typedef struct gds_descriptor {
  */
 int gds_stream_post_descriptors(CUstream stream, size_t n_descs, gds_descriptor_t *descs, int flags);
 
+/* \brief: CPU-synchronous post descriptors for peer QPs
+ *
+ * Notes:
+ * - This API might have higher overhead than issuing multiple ibv_post_send. 
+ * - It is provided for convenience only.
+ * - It might fail if trying to access CUDA device memory pointers
+ */
+int gds_post_descriptors(CUstream stream, size_t n_descs, gds_descriptor_t *descs, int flags);
+
+
 /*
  * Local variables:
  *  c-indent-level: 8

--- a/include/gdsync/core.h
+++ b/include/gdsync/core.h
@@ -285,11 +285,25 @@ typedef struct gds_descriptor {
 } gds_descriptor_t;
 
 /**
- * flags: must be 0
+ * \brief: post descriptors for peer QPs synchronized to the specified CUDA stream
+ *
+ * \param flags - must be 0
+ *
+ * \return
+ * 0 on success or one standard errno error
+ *
  */
 int gds_stream_post_descriptors(CUstream stream, size_t n_descs, gds_descriptor_t *descs, int flags);
 
-/* \brief: CPU-synchronous post descriptors for peer QPs
+/**
+ * \brief: CPU-synchronous post descriptors for peer QPs
+ *
+ *
+ * \param flags - must be 0
+ *
+ * \return
+ * 0 on success or one standard errno error
+ * 
  *
  * Notes:
  * - This API might have higher overhead than issuing multiple ibv_post_send. 

--- a/src/gdsync.cpp
+++ b/src/gdsync.cpp
@@ -107,7 +107,7 @@ int gds_flusher_enabled()
 #define GDS_HAS_MEMBAR      0
 #endif
 
-// TODO: use corret value
+// TODO: use correct value
 // TODO: make it dependent upon the particular GPU
 const size_t GDS_GPU_MAX_INLINE_SIZE = 256;
 

--- a/src/gdsync.cpp
+++ b/src/gdsync.cpp
@@ -932,7 +932,7 @@ out:
 
 //-----------------------------------------------------------------------------
 
-static int gds_post_ops_on_cpu(size_t n_descs, struct peer_op_wr *op)
+int gds_post_ops_on_cpu(size_t n_descs, struct peer_op_wr *op)
 {
         int retcode = 0;
         size_t n = 0;

--- a/src/gdsync.cpp
+++ b/src/gdsync.cpp
@@ -932,17 +932,18 @@ out:
 
 //-----------------------------------------------------------------------------
 
-int gds_post_ops_on_cpu(size_t n_descs, struct peer_op_wr *op)
+int gds_post_ops_on_cpu(size_t n_ops, struct peer_op_wr *op, int post_flags)
 {
         int retcode = 0;
         size_t n = 0;
-
-        for (; op && n < n_descs; op = op->next, ++n) {
+        gds_dbg("n_ops=%zu op=%p post_flags=0x%x\n", n_ops, op, post_flags);
+        for (; op && n < n_ops; op = op->next, ++n) {
                 //int flags = 0;
-                gds_dbg("op[%zu] type:%08x\n", n, op->type);
+                gds_dbg("op[%zu]=%p\n", n, op);
+                //gds_dbg("op[%zu]=%p type:%08x\n", n, op, op->type);
                 switch(op->type) {
                 case IBV_EXP_PEER_OP_FENCE: {
-                        gds_dbg("fence_flags=%"PRIu64"\n", op->wr.fence.fence_flags);
+                        gds_dbg("FENCE flags=%"PRIu64"\n", op->wr.fence.fence_flags);
                         uint32_t fence_op = (op->wr.fence.fence_flags & (IBV_EXP_PEER_FENCE_OP_READ|IBV_EXP_PEER_FENCE_OP_WRITE));
                         uint32_t fence_from = (op->wr.fence.fence_flags & (IBV_EXP_PEER_FENCE_FROM_CPU|IBV_EXP_PEER_FENCE_FROM_HCA));
                         uint32_t fence_mem = (op->wr.fence.fence_flags & (IBV_EXP_PEER_FENCE_MEM_SYS|IBV_EXP_PEER_FENCE_MEM_PEER));
@@ -978,30 +979,58 @@ int gds_post_ops_on_cpu(size_t n_descs, struct peer_op_wr *op)
                         uint32_t *ptr = (uint32_t*)((ptrdiff_t)range_from_id(op->wr.dword_va.target_id)->va + op->wr.dword_va.offset);
                         uint32_t data = op->wr.dword_va.data;
                         // A || B || C || E
+                        gds_dbg("STORE_DWORD ptr=%p data=%08"PRIx32"\n", ptr, data);
                         ACCESS_ONCE(*ptr) = data;
-                        gds_dbg("%p <- %08x\n", ptr, data);
                         break;
                 }
                 case IBV_EXP_PEER_OP_STORE_QWORD: {
                         uint64_t *ptr = (uint64_t*)((ptrdiff_t)range_from_id(op->wr.qword_va.target_id)->va + op->wr.qword_va.offset);
                         uint64_t data = op->wr.qword_va.data;
+                        gds_dbg("STORE_QWORD ptr=%p data=%016"PRIx64"\n", ptr, data);
                         ACCESS_ONCE(*ptr) = data;
-                        gds_dbg("%p <- %016"PRIx64"\n", ptr, data);
                         break;
                 }
                 case IBV_EXP_PEER_OP_COPY_BLOCK: {
                         uint64_t *ptr = (uint64_t*)((ptrdiff_t)range_from_id(op->wr.copy_op.target_id)->va + op->wr.copy_op.offset);
                         uint64_t *src = (uint64_t*)op->wr.copy_op.src;
                         size_t n_bytes = op->wr.copy_op.len;
+                        gds_dbg("COPY_BLOCK ptr=%p src=%p len=%zu\n", ptr, src, n_bytes);
                         gds_bf_copy(ptr, src, n_bytes);
-                        gds_dbg("%p <- %p len=%zu\n", ptr, src, n_bytes);
                         break;
                 }
                 case IBV_EXP_PEER_OP_POLL_AND_DWORD:
                 case IBV_EXP_PEER_OP_POLL_GEQ_DWORD:
                 case IBV_EXP_PEER_OP_POLL_NOR_DWORD: {
-                        gds_err("polling is not supported\n");
-                        retcode = EINVAL;
+                        int poll_cond;
+                        uint32_t *ptr = (uint32_t*)((ptrdiff_t)range_from_id(op->wr.dword_va.target_id)->va + op->wr.dword_va.offset);
+                        uint32_t value = op->wr.dword_va.data;
+                        bool flush = true;
+                        if (post_flags & GDS_POST_OPS_DISCARD_WAIT_FLUSH)
+                                flush = false;
+                        gds_dbg("WAIT_32 dev_ptr=%p data=%"PRIx32"\n", ptr, value);
+                        bool done = false;
+                        do {
+                                uint32_t data = gds_atomic_get(ptr);
+                                switch(op->type) {
+                                case IBV_EXP_PEER_OP_POLL_NOR_DWORD:
+                                        done = ~(data | value);
+                                        break;
+                                case IBV_EXP_PEER_OP_POLL_GEQ_DWORD:
+                                        done = ((int32_t)data - (int32_t)value >= 0);
+                                        break;
+                                case IBV_EXP_PEER_OP_POLL_AND_DWORD:
+                                        done = (data & value);
+                                        break;
+                                default:
+                                        gds_err("invalid op type %02x\n", op->type);
+                                        retcode = EINVAL;
+                                        goto out;
+                                }
+                                if (done)
+                                        break;
+                                // TODO: more aggressive CPU relaxing needed here to avoid starving I/O fabric
+                                arch_cpu_relax();
+                        } while(true);
                         break;
                 }
                 default:
@@ -1010,12 +1039,10 @@ int gds_post_ops_on_cpu(size_t n_descs, struct peer_op_wr *op)
                         break;
                 }
                 if (retcode) {
-                        gds_err("error in fill func at entry n=%zu\n", n);
+                        gds_err("error %d at entry n=%zu\n", retcode, n);
                         goto out;
                 }
         }
-
-        assert(n_descs == n);
 
 out:
         return retcode;

--- a/src/mlnxutils.h
+++ b/src/mlnxutils.h
@@ -66,9 +66,10 @@
 
 #endif
 // no WQ wrap-around check!!!
-static void gds_bf_copy(uint64_t *dest, uint64_t *src, size_t n_bytes)
+static inline void gds_bf_copy(uint64_t *dest, uint64_t *src, size_t n_bytes)
 {
         assert(n_bytes % sizeof(uint64_t) == 0);
+        assert(n_bytes < 128);
 	while (n_bytes > 0) {
 		COPY_64B_NT(dest, src);
 		n_bytes -= 8 * sizeof(*dest);

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -189,7 +189,7 @@ enum gds_post_ops_flags {
 
 struct gds_peer;
 int gds_post_ops(gds_peer *peer, size_t n_ops, struct peer_op_wr *op, gds_op_list_t &params, int post_flags = 0);
-
+int gds_post_ops_on_cpu(size_t n_descs, struct peer_op_wr *op);
 gds_peer *peer_from_stream(CUstream stream);
 
 //-----------------------------------------------------------------------------

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -46,7 +46,21 @@
 
 #define CUCHECK(stmt) __CUCHECK(stmt, #stmt)
 
+#ifndef ACCESS_ONCE
 #define ACCESS_ONCE(x) (*(volatile typeof(x) *)&(x))
+#endif
+
+template <typename T>
+static inline void gds_atomic_set(T *ptr, T value)
+{
+        ACCESS_ONCE(*ptr) = value;
+}
+
+template <typename T>
+static inline T gds_atomic_get(T *ptr)
+{
+        return ACCESS_ONCE(*ptr);
+}
 
 #define ROUND_UP(V,SIZE) (((V)+(SIZE)-1)/(SIZE)*(SIZE))
 
@@ -189,7 +203,7 @@ enum gds_post_ops_flags {
 
 struct gds_peer;
 int gds_post_ops(gds_peer *peer, size_t n_ops, struct peer_op_wr *op, gds_op_list_t &params, int post_flags = 0);
-int gds_post_ops_on_cpu(size_t n_descs, struct peer_op_wr *op);
+int gds_post_ops_on_cpu(size_t n_descs, struct peer_op_wr *op, int post_flags = 0);
 gds_peer *peer_from_stream(CUstream stream);
 
 //-----------------------------------------------------------------------------

--- a/tests/gds_kernel_loopback_latency.c
+++ b/tests/gds_kernel_loopback_latency.c
@@ -707,7 +707,7 @@ static void usage(const char *argv0)
 	printf("  -S, --gpu-calc-size=<size>  size of GPU compute buffer (default 128KB)\n");
 	printf("  -G, --gpu-id           use specified GPU (default 0)\n");
 	printf("  -B, --batch-length=<n> max batch length (default 20)\n");
-	printf("  -P, --peersync            enable GPUDirect PeerSync support (default enabled)\n");
+	printf("  -P, --peersync            disable GPUDirect PeerSync support (default enabled)\n");
 	printf("  -C, --peersync-gpu-cq     enable GPUDirect PeerSync GPU CQ support (default disabled)\n");
 	printf("  -D, --peersync-gpu-dbrec  enable QP DBREC on GPU memory (default disabled)\n");
 	printf("  -U, --peersync-desc-apis  use batched descriptor APIs (default disabled)\n");

--- a/tests/gpu.cpp
+++ b/tests/gpu.cpp
@@ -217,10 +217,12 @@ int gpu_launch_kernel(size_t size, int is_peersync)
 int gpu_launch_kernel_on_stream(size_t size, int is_peersync, CUstream s)
 {
         int ret = 0;
-        if (0 == size)
+        if (0 == size) {
+                gpu_warn_once("void kernel has extremely low launch latency\n");
                 gpu_launch_void_kernel_on_stream(s);
-        else
+        } else {
                 gpu_launch_calc_kernel_on_stream(size, s);
+        }
         assert(cudaSuccess == cudaGetLastError());
         return ret;
 }

--- a/tests/gpu.h
+++ b/tests/gpu.h
@@ -137,6 +137,8 @@ enum gpu_msg_level {
 #define gpu_info(FMT, ARGS...) gpu_msg(GPU_MSG_INFO,  "INFO: ", FMT, ## ARGS)
 #define gpu_infoc(CNT, FMT, ARGS...) do { static int __cnt = 0; if (__cnt++ < CNT) gpu_info(FMT, ## ARGS); } while(0)
 #define gpu_warn(FMT, ARGS...) gpu_msg(GPU_MSG_WARN,  "WARN: ", FMT, ## ARGS)
+#define gpu_warnc(CNT, FMT, ARGS...) do { static int __cnt = 0; if (__cnt++ < CNT) gpu_msg(GPU_MSG_WARN,  "WARN: ", FMT, ## ARGS); } while(0)
+#define gpu_warn_once(FMT, ARGS...) gpu_warnc(1, FMT, ##ARGS)
 #define gpu_err(FMT, ARGS...)  gpu_msg(GPU_MSG_ERROR, "ERR:  ", FMT, ##ARGS)
 
 // oversubscribe SM by factor 2


### PR DESCRIPTION
These changes help evaluating the relative performance of the direct Async (GPU->NIC) vs offloaded (GPU->CPU->NIC) path.