### PR TITLE
RFC - Expose send params driver bypass

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -6,7 +6,7 @@ AM_CPPFLAGS += -I$(srcdir)/src
 #AM_CPPFLAGS += -I$(CUDA_PATH)/include
 AM_CPPFLAGS += -D__STDC_FORMAT_MACROS
 
-#AM_LDFLAGS   = -L$(CUDA_PATH)/lib64
+AM_LDFLAGS = -lmlx5
 LIBGDSTOOLS = @LIBGDSTOOLS@
 LIBNVTX = @LIBNVTX@
 
@@ -73,7 +73,7 @@ bin_PROGRAMS = tests/gds_kernel_latency tests/gds_poll_lat tests/gds_kernel_loop
 noinst_PROGRAMS = tests/rstest tests/wqtest
 
 tests_gds_kernel_latency_SOURCES = tests/gds_kernel_latency.c tests/gpu_kernels.cu tests/pingpong.c tests/gpu.cpp
-tests_gds_kernel_latency_LDADD = $(top_builddir)/src/libgdsync.la -lmpi $(LIBGDSTOOLS) -lgdrapi $(LIBNVTX) -lcuda -lcudart $(PTHREAD_LIBS)
+tests_gds_kernel_latency_LDADD = $(top_builddir)/src/libgdsync.la -lmpi $(LIBGDSTOOLS) -lgdrapi -lmlx5 $(LIBNVTX) -lcuda -lcudart $(PTHREAD_LIBS)
 
 tests_rstest_SOURCES = tests/rstest.cpp
 tests_rstest_LDADD = 
@@ -82,20 +82,20 @@ tests_wqtest_SOURCES = tests/task_queue_test.cpp
 tests_wqtest_LDADD = $(PTHREAD_LIBS)
 
 tests_gds_poll_lat_SOURCES = tests/gds_poll_lat.c tests/gpu.cpp tests/gpu_kernels.cu
-tests_gds_poll_lat_LDADD = $(top_builddir)/src/libgdsync.la $(LIBGDSTOOLS) -lgdrapi -lmpi $(LIBNVTX) -lcuda -lcudart $(PTHREAD_LIBS)
+tests_gds_poll_lat_LDADD = $(top_builddir)/src/libgdsync.la $(LIBGDSTOOLS) -lgdrapi -lmlx5 -lmpi $(LIBNVTX) -lcuda -lcudart $(PTHREAD_LIBS)
 
 tests_gds_sanity_SOURCES = tests/gds_sanity.cpp tests/gpu.cpp tests/gpu_kernels.cu
-tests_gds_sanity_LDADD = $(top_builddir)/src/libgdsync.la $(LIBGDSTOOLS) -lgdrapi -lmpi $(LIBNVTX) -lcuda -lcudart $(PTHREAD_LIBS)
+tests_gds_sanity_LDADD = $(top_builddir)/src/libgdsync.la $(LIBGDSTOOLS) -lgdrapi -lmlx5 -lmpi $(LIBNVTX) -lcuda -lcudart $(PTHREAD_LIBS)
 
 tests_gds_kernel_loopback_latency_SOURCES = tests/gds_kernel_loopback_latency.c tests/pingpong.c tests/gpu.cpp tests/gpu_kernels.cu
-tests_gds_kernel_loopback_latency_LDADD = $(top_builddir)/src/libgdsync.la $(LIBGDSTOOLS) -lgdrapi $(LIBNVTX) -lcuda -lcudart $(PTHREAD_LIBS)
+tests_gds_kernel_loopback_latency_LDADD = $(top_builddir)/src/libgdsync.la $(LIBGDSTOOLS) -lgdrapi -lmlx5 $(LIBNVTX) -lcuda -lcudart $(PTHREAD_LIBS)
 
 endif
 
 SUFFIXES= .cu
 
 .cu.o:
-	$(NVCC) $(CPPFLAGS) $(AM_CPPFLAGS) $(NVCCFLAGS) $(GENCODE_FLAGS) -c -o $@ $<
+	$(NVCC) $(CPPFLAGS) $(AM_LDFLAGS)  $(AM_CPPFLAGS) $(NVCCFLAGS) $(GENCODE_FLAGS) -c -o $@ $<
 
 .cu.lo:
 	$(LIBTOOL) --tag=CXX --mode=compile $(top_srcdir)/cudalt $(NVCC) --resource-usage -o $@ -c $< $(CPPFLAGS) $(AM_CPPFLAGS) $(NVCCFLAGS) $(GENCODE_FLAGS)

--- a/configure.ac
+++ b/configure.ac
@@ -47,6 +47,18 @@ else
     fi
 fi
 
+AC_ARG_WITH([libmlx5],
+    AC_HELP_STRING([--with-libmlx5], [ Set path to libmlx5s installation ]))
+if test x$with_libmlx5 = x || test x$with_libmlx5 = xno; then
+    want_libmlx5=no
+else
+    want_libmlx5=yes
+    if test -d $with_libmlx5; then
+        CPPFLAGS="$CPPFLAGS -I$with_libmlx5/include"
+        LDFLAGS="$LDFLAGS -L$with_libmlx5/lib"
+    fi
+fi
+
 AC_ARG_WITH([gdrcopy],
     AC_HELP_STRING([--with-gdrcopy], [ Set path to gdrcopy installation ]))
 if test x$with_gdrcopy = x || test x$with_gdrcopy = xno; then
@@ -149,6 +161,13 @@ AC_CHECK_LIB(ibverbs, ibv_exp_create_qp,
 
 AC_CHECK_HEADER(infiniband/peer_ops.h, [],
     AC_MSG_ERROR([<infiniband/peer_ops.h> not found.  libgdsync requires verbs peer-direct support.]))
+
+AC_CHECK_HEADERS([infiniband/mlx5dv.h], [],
+    AC_MSG_ERROR([<infiniband/peer_ops.h> not found.  libgdsync requires verbs peer-direct support.]))
+
+AC_CHECK_DECLS([mlx5dv_init_obj],
+               [], [], [[#include <infiniband/mlx5dv.h>]])
+
 AC_HEADER_STDC
 
 dnl Checks for typedefs, structures, and compiler characteristics.
@@ -175,11 +194,10 @@ LDFLAGS="$LDFLAGS -L$CUDA_DRV_PATH/lib64 -L$CUDA_DRV_PATH/lib -L$CUDA_PATH/lib64
 NVCCFLAGS="$NVCCFLAGS"
 CUDA_CFLAGS="$CUDA_CFLAGS"
 CUDA_LDFLAGS="-L$CUDA_DRV_PATH/lib64 -L$CUDA_DRV_PATH/lib -L$CUDA_PATH/lib64 -L$CUDA_PATH/lib"
-CUDA_LIBS="-lcuda -lcudart -lcufft"
+CUDA_LIBS="-lcuda -lcudart -lcufft -lmlx5"
 NVCCFLAGS="$NVCCFLAGS $CUDA_CFLAGS $CUDA_LDFLAGS $CUDA_LIBS"
 AC_SUBST(NVCC, [nvcc])
 AC_SUBST(NVCCFLAGS)
-
 
 dnl AC_CHECK_MEMBER([union CUstreamBatchMemOpParams_union.flushRemoteWrites],
 dnl   [AC_SUBST( HAS_CUDA_MEMOP_FLUSH_REMOTE_WRITES, 1 )],

--- a/include/gdsync/core.h
+++ b/include/gdsync/core.h
@@ -39,6 +39,8 @@
     ( ((((v) & 0xffff0000U) >> 16) == GDS_API_MAJOR_VERSION) &&   \
       ((((v) & 0x0000ffffU) >> 0 ) >= GDS_API_MINOR_VERSION) )
 
+#define IBV_EXP_SEND_GET_INFO (1 << 28)
+
 typedef enum gds_param {
     GDS_PARAM_VERSION,
     GDS_NUM_PARAMS
@@ -68,6 +70,11 @@ struct gds_qp {
         struct gds_cq recv_cq;
         struct ibv_exp_res_domain * res_domain;
         struct ibv_context *dev_context;
+
+        void* swq; //send work queue pointer
+        size_t swq_cnt; //counter tracking swq location
+        size_t swq_size; //size of the swq (Blocks)
+        size_t swq_stride; //size of Blocks
 };
 
 /* \brief: Create a peer-enabled QP attached to the specified GPU id.
@@ -159,8 +166,23 @@ typedef enum gds_update_send_info_type {
  * Represents a posted send operation on a particular QP
  */
 
+#define GDS_SEND_MAX_SGE 16
+
+struct ptr_to_sge{
+    uintptr_t ptr_to_size;
+    uintptr_t ptr_to_lkey;
+    uintptr_t ptr_to_addr;
+    int offset;
+};
+
+struct gds_swr_info{
+    size_t num_sge;
+    struct ptr_to_sge sge_list[GDS_SEND_MAX_SGE];
+    size_t wr_id;
+};
+
 typedef struct gds_send_request_info {
-    struct ibv_qp_swr_info swr_info;
+    struct gds_swr_info swr_info;
     //Size info
     uintptr_t ptr_to_size_wqe_h;
     CUdeviceptr ptr_to_size_wqe_d;
@@ -350,6 +372,35 @@ int gds_stream_post_descriptors(CUstream stream, size_t n_descs, gds_descriptor_
  */
 int gds_post_descriptors(size_t n_descs, gds_descriptor_t *descs, int flags);
 
+/**
+ * \brief: TODO
+ *
+ *
+ * \param flags - TODO
+ *
+ * \return
+ * 0 on success or one standard errno error
+ *
+ *
+ * Notes:
+ * - TODO.
+ */
+int gds_report_post(struct gds_qp *gqp  /*, struct gds_send_wr* wr*/);
+
+/**
+ * \brief: TODO
+ *
+ *
+ * \param flags - TODO
+ *
+ * \return
+ * 0 on success or one standard errno error
+ *
+ *
+ * Notes:
+ * - TODO.
+ */
+int gds_query_last_info(struct gds_qp* qp, struct gds_swr_info* gds_info);
 
 /*
  * Local variables:

--- a/src/apis.cpp
+++ b/src/apis.cpp
@@ -127,13 +127,14 @@ out:
 //-----------------------------------------------------------------------------
 
 #define ntohll(x) (((uint64_t)(ntohl((int)((x << 32) >> 32))) << 32) |  (uint32_t)ntohl(((int)(x >> 32))))
-static void gds_dump_swr(const char * func_name, struct ibv_qp_swr_info swr_info)
+
+static void gds_dump_swr(const char * func_name, struct gds_swr_info swr_info)
 {
     gds_dbg("[%s] wr_id=%lx, num_sge=%d\n", func_name, swr_info.wr_id, swr_info.num_sge);
 
     for(int j=0; j < swr_info.num_sge; j++)
     {
-        gds_dbg("[%s]    SGE=%d, Size ptr=0x%08x, Size=%d (0x%08x), +offset=%d\n", 
+        gds_dbg("[%s]    SGE=%d, Size ptr=00x%lx, Size=%d (0x%08x), +offset=%d\n",
             func_name,
             j,
             (uintptr_t)swr_info.sge_list[j].ptr_to_size, 
@@ -141,14 +142,14 @@ static void gds_dump_swr(const char * func_name, struct ibv_qp_swr_info swr_info
             (uint32_t) ((uint32_t*)swr_info.sge_list[j].ptr_to_size)[0],
             ((uint32_t) ntohl( ((uint32_t*)swr_info.sge_list[j].ptr_to_size)[0]) ) + swr_info.sge_list[j].offset );
 
-        gds_dbg("[%s]    SGE=%d, lkey ptr=0x%08x, lkey=%d (0x%08x)\n", 
+        gds_dbg("[%s]    SGE=%d, lkey ptr=00x%lx, lkey=%d (0x%08x)\n", 
             func_name,
             j,
             (uintptr_t)swr_info.sge_list[j].ptr_to_lkey, 
             (uint32_t) ntohl( ((uint32_t*)swr_info.sge_list[j].ptr_to_lkey)[0]) ,
             (uint32_t) ((uint32_t*)swr_info.sge_list[j].ptr_to_lkey)[0]);
 
-        gds_dbg("[%s]    SGE=%d, Addr ptr=%lx, Addr=%lx -offset=%lx\n", 
+        gds_dbg("[%s]    SGE=%d, Addr ptr=00x%lx, Addr=%lx -offset=%lx\n",
             func_name,
             j,
             (uintptr_t)swr_info.sge_list[j].ptr_to_addr, 
@@ -233,7 +234,7 @@ int gds_prepare_send(struct gds_qp *qp, gds_send_wr *p_ewr,
                             (int)p_ewr->sg_list[i].length
                 );
             }
-            memset(&(request->gds_sinfo.swr_info), 0, sizeof(struct ibv_qp_swr_info));
+            memset(&(request->gds_sinfo.swr_info), 0, sizeof(struct gds_swr_info));
         }
 
         ret = ibv_exp_post_send(qp->qp, p_ewr, bad_ewr);
@@ -246,18 +247,19 @@ int gds_prepare_send(struct gds_qp *qp, gds_send_wr *p_ewr,
                 }
                 goto out;
         }
-    
+
         if(get_info)
         {
-            ret = ibv_exp_query_send_info(qp->qp, p_ewr->wr_id, &(request->gds_sinfo.swr_info));
+            ret = gds_query_last_info(qp, &(request->gds_sinfo.swr_info));
             if(ret)
             {
-                fprintf(stderr, "ibv_exp_query_send_info returned %d: %s\n", ret, strerror(ret));
+                fprintf(stderr, "gds_query_last_info returned %d: %s\n", ret, strerror(ret));
                 goto out;
             }
 
             gds_dump_swr("gds_prepare_send", request->gds_sinfo.swr_info);
         }
+        ret = gds_report_post(qp /*, p_ewr*/); //increment counter.
 
         ret = ibv_exp_peer_commit_qp(qp->qp, &request->commit);
         if (ret) {
@@ -1178,6 +1180,58 @@ int gds_post_descriptors(size_t n_descs, gds_descriptor_t *descs, int flags)
         }
 out:
         return ret;
+}
+
+struct mlx5_sge{
+    uint32_t byte_count;
+    uint32_t key;
+    uint64_t addr;
+};
+
+struct mlx5_send_wqe{
+    uint32_t ctrl1;
+    uint32_t qpn_ds;
+    uint64_t ctrl34;
+    uint64_t send12;
+    uint64_t send34;
+    struct mlx5_sge sge;
+};
+
+int gds_report_post(struct gds_qp *qp  /*, struct gds_send_wr* wr*/){
+    ++(qp->swq_cnt);
+    return 0;
+    /*//Smarter Alternative for cases we use larger wqes:
+    struct mlx5_send_wqe* wqe = (struct mlx5_send_wqe*)  ((char*) qp->swq + qp->swq_stride * ((qp->swq_cnt) % qp->swq_size));
+    size_t ds = (ntohl(wqe->qpn_ds) & (0x0000007f));
+    size_t wqes_per_block = (qp->swq_stride / sizeof(mlx5_sge));
+    size_t num_blocks = ds / wqes_per_block + !!(ds % wqes_per_block);
+    (qp->swq_cnt)+=num_blocks;
+    return 0;
+    */
+}
+
+int gds_query_last_info(struct gds_qp *qp, struct gds_swr_info* gds_info){
+    struct mlx5_send_wqe* wqe = (struct mlx5_send_wqe*)  ((char*) qp->swq + qp->swq_stride * ((qp->swq_cnt) % qp->swq_size));
+    gds_info->num_sge = (ntohl(wqe->qpn_ds) & (0x0000007f)) - 2;
+    struct mlx5_sge* sge = &(wqe->sge);
+    size_t blocks_per_wqe = (qp->swq_stride / sizeof(mlx5_sge));
+
+    uint16_t blocks_left = ((qp->swq_size - (qp->swq_cnt % qp->swq_size)) * qp->swq_stride) - 2;
+    //we need to monitor how many blocks we have left before wrap around.
+
+    for (size_t i = 0; i< gds_info->num_sge; ++i){
+        gds_info->sge_list[i].ptr_to_size = (uintptr_t) &(sge->byte_count);
+        gds_info->sge_list[i].ptr_to_lkey = (uintptr_t) &(sge->key);
+        gds_info->sge_list[i].ptr_to_addr = (uintptr_t) &(sge->addr);
+        gds_info->sge_list[i].offset = 0; //why is that here?
+        if (i == blocks_left){
+          sge = (struct mlx5_sge*) qp->swq;
+        } else {
+          (++sge);
+        }
+    }
+    gds_info->wr_id = 1;  //just exists to match old API.
+    return 0;
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This code should be compared with the upstream/expose_send_params branch

The goal of those commits is to allow the changes in the "Expose send params" branch to work without the required changes to the mlx5 driver. This is done by using direct verbs to extract driver info.

The method to bypass the driver is:
1. Use Direct verbs to create the mlx5dv_qp object after qp creation, from which a pointer to the send queue and the send_queue size can be extracted.
2. extend the gds qp context to hold additional fields: the send queue pointer and size extracted in the procedure above, and a counter that tracks the wqes being used in the send queue.
3. The counter is to updated in each call to gds_post_send, by calling gds_report_post.
4. gds_query_last_info() is implemented using the counter, pointer and size of send queue kept in the gds qp context. Only the last work-request can be probed. 
5. number of sges is determined by probing the opcode and ds from the last wqe.Number of BB consumed in the send queue can be checked in the same way but currently is fixed to 1.


I haven't yet managed to run all the tests in gda successfully (with or without this patch), but I was able to run:
Running gds_kernel_latency, peersync, descriptors, RC
Running gds_kernel_latency, peersync, descriptors, GMEM buffers, RC

without errors/hangs, after changing the hard coded number of batches in the test to 1.

@haggaie @bureddy @drossetti @e-ago 