### PR TITLE
Remove exp-verbs from public API

### DIFF
--- a/include/gdsync.h
+++ b/include/gdsync.h
@@ -33,7 +33,6 @@
  */
 
 #include <infiniband/verbs.h>
-#include <infiniband/peer_ops.h>
 
 #include <cuda.h>
 #include <gdrapi.h>

--- a/include/gdsync.h
+++ b/include/gdsync.h
@@ -33,7 +33,6 @@
  */
 
 #include <infiniband/verbs.h>
-#include <infiniband/verbs_exp.h>
 #include <infiniband/peer_ops.h>
 
 #include <cuda.h>

--- a/include/gdsync/core.h
+++ b/include/gdsync/core.h
@@ -36,22 +36,22 @@
 #define GDS_API_MINOR_VERSION    2U
 #define GDS_API_VERSION          ((GDS_API_MAJOR_VERSION << 16) | GDS_API_MINOR_VERSION)
 #define GDS_API_VERSION_COMPATIBLE(v) \
-    ( ((((v) & 0xffff0000U) >> 16) == GDS_API_MAJOR_VERSION) &&   \
-      ((((v) & 0x0000ffffU) >> 0 ) >= GDS_API_MINOR_VERSION) )
+        ( ((((v) & 0xffff0000U) >> 16) == GDS_API_MAJOR_VERSION) &&   \
+          ((((v) & 0x0000ffffU) >> 0 ) >= GDS_API_MINOR_VERSION) )
 
 typedef enum gds_param {
-    GDS_PARAM_VERSION,
-    GDS_NUM_PARAMS
+        GDS_PARAM_VERSION,
+        GDS_NUM_PARAMS
 } gds_param_t;
 
 int gds_query_param(gds_param_t param, int *value);
 
 enum gds_create_qp_flags {
-    GDS_CREATE_QP_DEFAULT      = 0,
-    GDS_CREATE_QP_WQ_ON_GPU    = 1<<0,
-    GDS_CREATE_QP_TX_CQ_ON_GPU = 1<<1,
-    GDS_CREATE_QP_RX_CQ_ON_GPU = 1<<2,
-    GDS_CREATE_QP_WQ_DBREC_ON_GPU = 1<<5,
+        GDS_CREATE_QP_DEFAULT      = 0,
+        GDS_CREATE_QP_WQ_ON_GPU    = 1<<0,
+        GDS_CREATE_QP_TX_CQ_ON_GPU = 1<<1,
+        GDS_CREATE_QP_RX_CQ_ON_GPU = 1<<2,
+        GDS_CREATE_QP_WQ_DBREC_ON_GPU = 1<<5,
 };
 
 typedef struct ibv_qp_init_attr gds_qp_init_attr_t;
@@ -76,8 +76,8 @@ typedef struct gds_qp {
  */
 
 gds_qp_t *gds_create_qp(struct ibv_pd *pd, struct ibv_context *context,
-                             gds_qp_init_attr_t *qp_init_attr,
-                             int gpu_id, int flags);
+                gds_qp_init_attr_t *qp_init_attr,
+                int gpu_id, int flags);
 
 /* \brief: Destroy a peer-enabled QP
  *
@@ -116,7 +116,7 @@ typedef enum gds_memory_type {
         GDS_MEMORY_GPU  = 1, /*< use this flag for both cudaMalloc/cuMemAlloc and cudaMallocHost/cuMemHostAlloc */
         GDS_MEMORY_HOST = 2,
         GDS_MEMORY_IO   = 4,
-	GDS_MEMORY_MASK = 0x7
+        GDS_MEMORY_MASK = 0x7
 } gds_memory_type_t;
 
 // Note: those flags below must not overlap with gds_memory_type_t
@@ -148,7 +148,7 @@ typedef enum gds_membar_flags {
  */
 
 typedef struct {
-    void *handle;
+        void *handle;
 } gds_send_request_t;
 
 int gds_prepare_send(gds_qp_t *qp, gds_send_wr *p_ewr, gds_send_wr **bad_ewr, gds_send_request_t *request);
@@ -161,7 +161,7 @@ int gds_stream_post_send_all(CUstream stream, int count, gds_send_request_t *req
  */
 
 typedef struct {
-    void *handle;
+        void *handle;
 }gds_wait_request_t;
 
 /**

--- a/include/gdsync/core.h
+++ b/include/gdsync/core.h
@@ -57,17 +57,17 @@ enum gds_create_qp_flags {
 typedef struct ibv_qp_init_attr gds_qp_init_attr_t;
 typedef struct ibv_send_wr gds_send_wr;
 
-struct gds_cq {
+typedef struct gds_cq {
         struct ibv_cq *cq;
         uint32_t curr_offset;
-};
+} gds_cq_t;
 
-struct gds_qp {
-        struct ibv_qp *qp;
-        struct gds_cq send_cq;
-        struct gds_cq recv_cq;
+typedef struct gds_qp {
+        struct ibv_qp      *qp;
+        gds_cq_t            send_cq;
+        gds_cq_t            recv_cq;
         struct ibv_context *dev_context;
-};
+} gds_qp_t;
 
 /* \brief: Create a peer-enabled QP attached to the specified GPU id.
  *
@@ -75,7 +75,7 @@ struct gds_qp {
  * use SRQ.
  */
 
-struct gds_qp *gds_create_qp(struct ibv_pd *pd, struct ibv_context *context,
+gds_qp_t *gds_create_qp(struct ibv_pd *pd, struct ibv_context *context,
                              gds_qp_init_attr_t *qp_init_attr,
                              int gpu_id, int flags);
 
@@ -83,7 +83,7 @@ struct gds_qp *gds_create_qp(struct ibv_pd *pd, struct ibv_context *context,
  *
  * The associated CQs are destroyed as well.
  */
-int gds_destroy_qp(struct gds_qp *qp);
+int gds_destroy_qp(gds_qp_t *qp);
 
 /* \brief: CPU-synchronous post send for peer QPs
  *
@@ -91,23 +91,23 @@ int gds_destroy_qp(struct gds_qp *qp);
  * - this API might have higher overhead than ibv_post_send. 
  * - It is provided for convenience only.
  */
-int gds_post_send(struct gds_qp *qp, gds_send_wr *wr, gds_send_wr **bad_wr);
+int gds_post_send(gds_qp_t *qp, gds_send_wr *wr, gds_send_wr **bad_wr);
 
 /* \brief: CPU-synchronous post recv for peer QPs
  *
  * Notes:
  * - there is no GPU-synchronous version of this because there is not a use case for it.
  */
-int gds_post_recv(struct gds_qp *qp, struct ibv_recv_wr *wr, struct ibv_recv_wr **bad_wr);
+int gds_post_recv(gds_qp_t *qp, struct ibv_recv_wr *wr, struct ibv_recv_wr **bad_wr);
 
-int gds_stream_wait_cq(CUstream stream, struct gds_cq *cq, int flags);
+int gds_stream_wait_cq(CUstream stream, gds_cq_t *cq, int flags);
 
 /* \brief: GPU stream-synchronous send for peer QPs
  *
  * Notes:
  * - execution of the send operation happens in CUDA stream order
  */
-int gds_stream_queue_send(CUstream stream, struct gds_qp *qp, gds_send_wr *p_ewr, gds_send_wr **bad_ewr);
+int gds_stream_queue_send(CUstream stream, gds_qp_t *qp, gds_send_wr *p_ewr, gds_send_wr **bad_ewr);
 
 
 // batched submission APIs
@@ -151,7 +151,7 @@ typedef struct {
     void *handle;
 } gds_send_request_t;
 
-int gds_prepare_send(struct gds_qp *qp, gds_send_wr *p_ewr, gds_send_wr **bad_ewr, gds_send_request_t *request);
+int gds_prepare_send(gds_qp_t *qp, gds_send_wr *p_ewr, gds_send_wr **bad_ewr, gds_send_request_t *request);
 int gds_stream_post_send(CUstream stream, gds_send_request_t *request);
 int gds_stream_post_send_all(CUstream stream, int count, gds_send_request_t *request);
 
@@ -173,7 +173,7 @@ void gds_free_wait_request(gds_wait_request_t *request);
  *
  * flags: must be 0
  */
-int gds_prepare_wait_cq(struct gds_cq *cq, gds_wait_request_t *request, int flags);
+int gds_prepare_wait_cq(gds_cq_t *cq, gds_wait_request_t *request, int flags);
 
 /**
  * Issues the descriptors contained in request on the CUDA stream
@@ -195,7 +195,7 @@ int gds_stream_post_wait_cq_all(CUstream stream, int count, gds_wait_request_t *
  * CQE poll-able.
  *
  */
-int gds_post_wait_cq(struct gds_cq *cq, gds_wait_request_t *request, int flags);
+int gds_post_wait_cq(gds_cq_t *cq, gds_wait_request_t *request, int flags);
 
 
 

--- a/include/gdsync/core.h
+++ b/include/gdsync/core.h
@@ -147,10 +147,9 @@ typedef enum gds_membar_flags {
  * Represents a posted send operation on a particular QP
  */
 
-typedef struct gds_send_request gds_send_request_t;
-
-int gds_alloc_send_request(gds_send_request_t **request, int num);
-void gds_free_send_request(gds_send_request_t *request);
+typedef struct {
+    void *handle;
+} gds_send_request_t;
 
 int gds_prepare_send(struct gds_qp *qp, gds_send_wr *p_ewr, gds_send_wr **bad_ewr, gds_send_request_t *request);
 int gds_stream_post_send(CUstream stream, gds_send_request_t *request);
@@ -161,7 +160,9 @@ int gds_stream_post_send_all(CUstream stream, int count, gds_send_request_t *req
  * Represents a wait operation on a particular CQ
  */
 
-typedef struct gds_wait_request gds_wait_request_t;
+typedef struct {
+    void *handle;
+}gds_wait_request_t;
 
 int gds_alloc_wait_request(gds_wait_request_t **request, int num);
 void gds_free_wait_request(gds_wait_request_t *request);
@@ -274,8 +275,8 @@ typedef enum gds_tag {
 typedef struct gds_descriptor {
         gds_tag_t tag; /**< selector for union below */
         union {
-                gds_send_request_t  *send;
-                gds_wait_request_t  *wait;
+                gds_send_request_t   send;
+                gds_wait_request_t   wait;
                 gds_wait_value32_t   wait32;
                 gds_write_value32_t  write32;
                 gds_write_memory_t   writemem;

--- a/include/gdsync/core.h
+++ b/include/gdsync/core.h
@@ -54,7 +54,7 @@ enum gds_create_qp_flags {
     GDS_CREATE_QP_WQ_DBREC_ON_GPU = 1<<5,
 };
 
-typedef struct ibv_exp_qp_init_attr gds_qp_init_attr_t;
+typedef struct ibv_qp_init_attr gds_qp_init_attr_t;
 typedef struct ibv_exp_send_wr gds_send_wr;
 
 struct gds_cq {

--- a/include/gdsync/core.h
+++ b/include/gdsync/core.h
@@ -164,9 +164,6 @@ typedef struct {
     void *handle;
 }gds_wait_request_t;
 
-int gds_alloc_wait_request(gds_wait_request_t **request, int num);
-void gds_free_wait_request(gds_wait_request_t *request);
-
 /**
  * Initializes a wait request out of the next heading CQE, which is kept in
  * cq->curr_offset.

--- a/include/gdsync/core.h
+++ b/include/gdsync/core.h
@@ -142,19 +142,15 @@ typedef enum gds_membar_flags {
         GDS_MEMBAR_MLX5         = 1<<7 /*< modify the scope of the barrier, for internal use only */
 } gds_membar_flags_t;
 
-enum {
-        GDS_SEND_INFO_MAX_OPS = 32,
-        GDS_WAIT_INFO_MAX_OPS = 32
-};
 
 /**
  * Represents a posted send operation on a particular QP
  */
 
-typedef struct gds_send_request {
-        struct ibv_exp_peer_commit commit;
-        struct peer_op_wr wr[GDS_SEND_INFO_MAX_OPS];
-} gds_send_request_t;
+typedef struct gds_send_request gds_send_request_t;
+
+int gds_alloc_send_request(gds_send_request_t **request, int num);
+void gds_free_send_request(gds_send_request_t *request);
 
 int gds_prepare_send(struct gds_qp *qp, gds_send_wr *p_ewr, gds_send_wr **bad_ewr, gds_send_request_t *request);
 int gds_stream_post_send(CUstream stream, gds_send_request_t *request);
@@ -165,10 +161,10 @@ int gds_stream_post_send_all(CUstream stream, int count, gds_send_request_t *req
  * Represents a wait operation on a particular CQ
  */
 
-typedef struct gds_wait_request {
-        struct ibv_exp_peer_peek peek;
-        struct peer_op_wr wr[GDS_WAIT_INFO_MAX_OPS];
-} gds_wait_request_t;
+typedef struct gds_wait_request gds_wait_request_t;
+
+int gds_alloc_wait_request(gds_wait_request_t **request, int num);
+void gds_free_wait_request(gds_wait_request_t *request);
 
 /**
  * Initializes a wait request out of the next heading CQE, which is kept in

--- a/include/gdsync/core.h
+++ b/include/gdsync/core.h
@@ -66,7 +66,6 @@ struct gds_qp {
         struct ibv_qp *qp;
         struct gds_cq send_cq;
         struct gds_cq recv_cq;
-        struct ibv_exp_res_domain * res_domain;
         struct ibv_context *dev_context;
 };
 

--- a/include/gdsync/core.h
+++ b/include/gdsync/core.h
@@ -55,7 +55,7 @@ enum gds_create_qp_flags {
 };
 
 typedef struct ibv_qp_init_attr gds_qp_init_attr_t;
-typedef struct ibv_exp_send_wr gds_send_wr;
+typedef struct ibv_send_wr gds_send_wr;
 
 struct gds_cq {
         struct ibv_cq *cq;

--- a/include/gdsync/core.h
+++ b/include/gdsync/core.h
@@ -272,8 +272,8 @@ typedef enum gds_tag {
 typedef struct gds_descriptor {
         gds_tag_t tag; /**< selector for union below */
         union {
-                gds_send_request_t   send;
-                gds_wait_request_t   wait;
+                gds_send_request_t   *send;
+                gds_wait_request_t   *wait;
                 gds_wait_value32_t   wait32;
                 gds_write_value32_t  write32;
                 gds_write_memory_t   writemem;

--- a/include/gdsync/core.h
+++ b/include/gdsync/core.h
@@ -162,7 +162,7 @@ int gds_stream_post_send_all(CUstream stream, int count, gds_send_request_t *req
 
 typedef struct {
         void *handle;
-}gds_wait_request_t;
+} gds_wait_request_t;
 
 /**
  * Initializes a wait request out of the next heading CQE, which is kept in

--- a/include/gdsync/mlx5.h
+++ b/include/gdsync/mlx5.h
@@ -52,7 +52,7 @@ typedef struct gds_mlx5_send_info {
 int gds_mlx5_get_send_info(int count, const gds_send_request_t *requests, gds_mlx5_send_info_t *mlx5_infos);
 
 typedef struct gds_mlx5_wait_info {
-	gds_wait_cond_flag_t cond;
+        gds_wait_cond_flag_t cond;
         uint32_t *cqe_ptr;
         uint32_t  cqe_value;
         uint32_t *flag_ptr;

--- a/include/gdsync/tools.h
+++ b/include/gdsync/tools.h
@@ -36,12 +36,12 @@
 GDS_BEGIN_DECLS
 
 typedef struct gds_mem_desc {
-    CUdeviceptr d_ptr;
-    void       *h_ptr;
-    void       *bar_ptr;
-    int         flags;
-    size_t      alloc_size;
-    gdr_mh_t    mh;
+        CUdeviceptr d_ptr;
+        void       *h_ptr;
+        void       *bar_ptr;
+        int         flags;
+        size_t      alloc_size;
+        gdr_mh_t    mh;
 } gds_mem_desc_t;
 int gds_alloc_mapped_memory(gds_mem_desc_t *desc, size_t size, int flags);
 int gds_free_mapped_memory(gds_mem_desc_t *desc);

--- a/src/apis.cpp
+++ b/src/apis.cpp
@@ -46,7 +46,6 @@
 #include "gdsync.h"
 #include "gdsync/tools.h"
 #include "objs.hpp"
-#include "utils.hpp"
 #include "memmgr.hpp"
 #include "utils.hpp"
 #include "archutils.h"
@@ -65,7 +64,7 @@ static void gds_init_ops(struct peer_op_wr *op, int count)
 
 //-----------------------------------------------------------------------------
 
-static void gds_init_send_info(gds_send_request_t *info)
+static void gds_init_send_info(gds_send_request_s *info)
 {
         gds_dbg("send_request=%p\n", info);
         memset(info, 0, sizeof(*info));
@@ -77,7 +76,7 @@ static void gds_init_send_info(gds_send_request_t *info)
 
 //-----------------------------------------------------------------------------
 
-static void gds_init_wait_request(gds_wait_request_t *request, uint32_t offset)
+static void gds_init_wait_request(gds_wait_request_s *request, uint32_t offset)
 {
         gds_dbg("wait_request=%p offset=%08x\n", request, offset);
         memset(request, 0, sizeof(*request));
@@ -90,7 +89,7 @@ static void gds_init_wait_request(gds_wait_request_t *request, uint32_t offset)
 
 //-----------------------------------------------------------------------------
 
-static int gds_rollback_qp(struct gds_qp *qp, gds_send_request_t * send_info, enum ibv_exp_rollback_flags flag)
+static int gds_rollback_qp(struct gds_qp *qp, gds_send_request_s * send_info, enum ibv_exp_rollback_flags flag)
 {
         struct ibv_exp_rollback_ctx rollback;
         int ret=0;
@@ -125,11 +124,65 @@ out:
 
 //-----------------------------------------------------------------------------
 
+static int gds_prepare_send_internal(struct gds_qp *qp, gds_send_wr *p_ewr, 
+                                        gds_send_wr **bad_ewr, 
+                                        gds_send_request_s *request)
+{
+    int ret = 0;
+    gds_init_send_info(request);
+    ret = ibv_post_send(qp->qp, p_ewr, bad_ewr);
+    if (ret) {
+        if (ret == ENOMEM) {
+            // out of space error can happen too often to report
+            gds_dbg("ENOMEM error %d in ibv_post_send\n", ret);
+        } else {
+            gds_err("error %d in ibv_post_send\n", ret);
+        }
+        goto out;
+    }
+
+    ret = ibv_exp_peer_commit_qp(qp->qp, &request->commit);
+    if (ret) {
+        gds_err("error %d in ibv_exp_peer_commit_qp\n", ret);
+        goto out;
+    }
+out:
+    return ret;
+}
+
+//-----------------------------------------------------------------------------
+
+static int gds_prepare_wait_cq_internal(struct gds_cq *cq, gds_wait_request_s *request, int flags)
+{
+    int retcode = 0;
+    if (flags != 0) {
+        gds_err("invalid flags != 0\n");
+        return EINVAL;
+    }
+
+    gds_init_wait_request(request, cq->curr_offset++);
+
+    retcode = ibv_exp_peer_peek_cq(cq->cq, &request->peek);
+    if (retcode == -ENOSPC) {
+        // TODO: handle too few entries
+        gds_err("not enough ops in peer_peek_cq\n");
+        goto out;
+    } else if (retcode) {
+        gds_err("error %d in peer_peek_cq\n", retcode);
+        goto out;
+    }
+    //gds_dump_wait_request(request, 1);
+out:
+    return retcode;
+}
+
+//-----------------------------------------------------------------------------
+
 int gds_post_send(struct gds_qp *qp, gds_send_wr *p_ewr, gds_send_wr **bad_ewr)
 {
         int ret = 0, ret_roll=0;
-        gds_send_request_t send_info;
-        ret = gds_prepare_send(qp, p_ewr, bad_ewr, &send_info);
+        gds_send_request_s send_info;
+        ret = gds_prepare_send_internal(qp, p_ewr, bad_ewr, &send_info);
         if (ret) {
                 gds_err("error %d in gds_prepare_send\n", ret);
                 goto out;
@@ -175,60 +228,56 @@ int gds_prepare_send(struct gds_qp *qp, gds_send_wr *p_ewr,
                      gds_send_wr **bad_ewr, 
                      gds_send_request_t *request)
 {
-        int ret = 0;
-        gds_init_send_info(request);
-        assert(qp);
-        assert(qp->qp);
-        ret = ibv_post_send(qp->qp, p_ewr, bad_ewr);
-        if (ret) {
+    int ret = 0;
+    gds_send_request_s *send_request;
+    assert(qp);
+    assert(qp->qp);
 
-                if (ret == ENOMEM) {
-                        // out of space error can happen too often to report
-                        gds_dbg("ENOMEM error %d in ibv_post_send\n", ret);
-                } else {
-                        gds_err("error %d in ibv_post_send\n", ret);
-                }
-                goto out;
-        }
-        
-        ret = ibv_exp_peer_commit_qp(qp->qp, &request->commit);
-        if (ret) {
-                gds_err("error %d in ibv_exp_peer_commit_qp\n", ret);
-                //gds_wait_kernel();
-                goto out;
-        }
-out:
+    send_request = (gds_send_request_s *)malloc(sizeof(gds_send_request_s));
+    if (send_request == NULL) {
+        gds_err("out of memory in gds_prepare_send\n");
+        return ENOMEM;
+    }
+
+    ret = gds_prepare_send_internal(qp, p_ewr, bad_ewr, send_request);
+    if (ret != 0) {
+        free(send_request);
         return ret;
+    }
+
+    request->handle = (void *)send_request;
+    
+    return ret;
 }
 
 //-----------------------------------------------------------------------------
 
 int gds_stream_queue_send(CUstream stream, struct gds_qp *qp, gds_send_wr *p_ewr, gds_send_wr **bad_ewr)
 {
-        int ret = 0, ret_roll = 0;
-        gds_send_request_t send_info;
-        gds_descriptor_t descs[1];
+    int ret = 0, ret_roll = 0;
+    gds_send_request_s send_info;
+    gds_descriptor_t descs[1];
 
-        assert(qp);
-        assert(p_ewr);
+    assert(qp);
+    assert(p_ewr);
 
-        ret = gds_prepare_send(qp, p_ewr, bad_ewr, &send_info);
-        if (ret) {
-                gds_err("error %d in gds_prepare_send\n", ret);
-                goto out;
-        }
+    ret = gds_prepare_send_internal(qp, p_ewr, bad_ewr, &send_info);
+    if (ret) {
+        gds_err("error %d in gds_prepare_send\n", ret);
+        goto out;
+    }
 
-        descs[0].tag = GDS_TAG_SEND;
-        descs[0].send = &send_info;
+    descs[0].tag = GDS_TAG_SEND;
+    descs[0].send.handle = &send_info;
 
-        ret=gds_stream_post_descriptors(stream, 1, descs, 0);
-        if (ret) {
-                gds_err("error %d in gds_stream_post_descriptors\n", ret);
-                goto out;
-        }
+    ret = gds_stream_post_descriptors(stream, 1, descs, GDS_FLAG_INTERNAL_KEEP_REQUESTS);
+    if (ret) {
+        gds_err("error %d in gds_stream_post_descriptors\n", ret);
+        goto out;
+    }
 
-        out:
-        return ret;
+out:
+    return ret;
 }
 
 //-----------------------------------------------------------------------------
@@ -247,100 +296,114 @@ int gds_stream_post_send(CUstream stream, gds_send_request_t *request)
 
 int gds_stream_post_send_all(CUstream stream, int count, gds_send_request_t *request)
 {
-        int ret = 0, k = 0;
-        gds_descriptor_t * descs = NULL;
+    int ret = 0, k = 0;
+    gds_descriptor_t * descs = NULL;
 
-        assert(request);
-        assert(count);
+    assert(request);
+    assert(count);
 
-        descs = (gds_descriptor_t *) calloc(count, sizeof(gds_descriptor_t));
-        if(!descs)
-        {
-                gds_err("Calloc for %d elements\n", count);
-                ret=ENOMEM;
-                goto out;
-        }
+    descs = (gds_descriptor_t *)calloc(count, sizeof(gds_descriptor_t));
+    if(!descs)
+    {
+        gds_err("Calloc for %d elements\n", count);
+        ret = ENOMEM;
+        goto out;
+    }
 
-        for (k=0; k<count; k++) {
-                descs[k].tag = GDS_TAG_SEND;
-                descs[k].send = &request[k];
-        }
+    for (k = 0; k < count; k++) {
+        descs[k].tag = GDS_TAG_SEND;
+        descs[k].send = request[k];
+    }
 
-        ret=gds_stream_post_descriptors(stream, count, descs, 0);
-        if (ret) {
-                gds_err("error %d in gds_stream_post_descriptors\n", ret);
-                goto out;
-        }
+    ret = gds_stream_post_descriptors(stream, count, descs, 0);
+    if (ret) {
+        gds_err("error %d in gds_stream_post_descriptors\n", ret);
+        goto out;
+    }
 
-        out:
-            if(descs) free(descs);
-            return ret;
+out:
+    for (k = 0; k < count; k++)
+        request[k].handle = NULL;
+
+    if (descs) 
+        free(descs);
+    return ret;
 }
 
 //-----------------------------------------------------------------------------
 
 int gds_prepare_wait_cq(struct gds_cq *cq, gds_wait_request_t *request, int flags)
 {
-        int retcode = 0;
-        if (flags != 0) {
-                gds_err("invalid flags != 0\n");
-                return EINVAL;
-        }
+    int ret = 0;
+    gds_wait_request_s *wait_request = (gds_wait_request_s *)malloc(sizeof(gds_wait_request_s));
 
-        gds_init_wait_request(request, cq->curr_offset++);
+    if (wait_request == NULL) {
+        gds_err("out of memory in gds_prepare_wait_cq\n");
+        return ENOMEM;
+    }
 
-        retcode = ibv_exp_peer_peek_cq(cq->cq, &request->peek);
-        if (retcode == -ENOSPC) {
-                // TODO: handle too few entries
-                gds_err("not enough ops in peer_peek_cq\n");
-                goto out;
-        } else if (retcode) {
-                gds_err("error %d in peer_peek_cq\n", retcode);
-                goto out;
-        }
-        //gds_dump_wait_request(request, 1);
-        out:
-	       return retcode;
+    ret = gds_prepare_wait_cq_internal(cq, wait_request, flags);
+    if (ret != 0) {
+        free(wait_request);
+        return ret;
+    }
+
+    request->handle = (void *)wait_request;
+
+    return ret;
 }
 
 //-----------------------------------------------------------------------------
 
 int gds_append_wait_cq(gds_wait_request_t *request, uint32_t *dw, uint32_t val)
 {
-        int ret = 0;
-        unsigned MAX_NUM_ENTRIES = sizeof(request->wr)/sizeof(request->wr[0]);
-        unsigned n = request->peek.entries;
-        struct peer_op_wr *wr = request->peek.storage;
+    int ret = 0;
+    gds_wait_request_s *wait_request = to_gds_wait_request_s(request);
+    unsigned MAX_NUM_ENTRIES = sizeof(wait_request->wr) / sizeof(wait_request->wr[0]);
+    unsigned n = wait_request->peek.entries;
+    struct peer_op_wr *wr = wait_request->peek.storage;
 
-        if (n + 1 > MAX_NUM_ENTRIES) {
-            gds_err("no space left to stuff a poke\n");
-            ret = ENOMEM;
-            goto out;
-        }
+    if (n + 1 > MAX_NUM_ENTRIES) {
+        gds_err("no space left to stuff a poke\n");
+        ret = ENOMEM;
+        goto out;
+    }
 
-        // at least 1 op
-        assert(n);
-        assert(wr);
+    // at least 1 op
+    assert(n);
+    assert(wr);
 
-        for (; n; --n) wr = wr->next;
-        assert(wr);
+    for (; n; --n) wr = wr->next;
+    assert(wr);
 
-        wr->type = IBV_EXP_PEER_OP_STORE_DWORD;
-        wr->wr.dword_va.data = val;
-        wr->wr.dword_va.target_id = 0; // direct mapping, offset IS the address
-        wr->wr.dword_va.offset = (ptrdiff_t)(dw-(uint32_t*)0);
+    wr->type = IBV_EXP_PEER_OP_STORE_DWORD;
+    wr->wr.dword_va.data = val;
+    wr->wr.dword_va.target_id = 0; // direct mapping, offset IS the address
+    wr->wr.dword_va.offset = (ptrdiff_t)(dw-(uint32_t*)0);
 
-        ++request->peek.entries;
+    ++wait_request->peek.entries;
 
-        out:
-        return ret;
+out:
+    return ret;
+}
+
+//-----------------------------------------------------------------------------
+
+static int gds_stream_post_wait_cq_internal(CUstream stream, gds_wait_request_s *request)
+{
+	return gds_stream_post_wait_cq_multi(stream, 1, request, NULL, 0);
 }
 
 //-----------------------------------------------------------------------------
 
 int gds_stream_post_wait_cq(CUstream stream, gds_wait_request_t *request)
 {
-	return gds_stream_post_wait_cq_multi(stream, 1, request, NULL, 0);
+    int ret = 0;
+    gds_wait_request_s *wait_request = to_gds_wait_request_s(request);
+	ret = gds_stream_post_wait_cq_internal(stream, wait_request);
+    free(wait_request);
+    request->handle = NULL;
+    return ret;
 }
 
 //-----------------------------------------------------------------------------
@@ -352,67 +415,70 @@ int gds_stream_post_wait_cq_all(CUstream stream, int count, gds_wait_request_t *
 
 //-----------------------------------------------------------------------------
 
-static int gds_abort_wait_cq(struct gds_cq *cq, gds_wait_request_t *request)
+static int gds_abort_wait_cq(struct gds_cq *cq, gds_wait_request_s *request)
 {
-        assert(cq);
-        assert(request);
-        struct ibv_exp_peer_abort_peek abort_ctx;
-        abort_ctx.peek_id = request->peek.peek_id;
-        abort_ctx.comp_mask = 0;
-        return ibv_exp_peer_abort_peek_cq(cq->cq, &abort_ctx);
+    assert(cq);
+    assert(request);
+    struct ibv_exp_peer_abort_peek abort_ctx;
+    abort_ctx.peek_id = request->peek.peek_id;
+    abort_ctx.comp_mask = 0;
+    return ibv_exp_peer_abort_peek_cq(cq->cq, &abort_ctx);
 }
 
 //-----------------------------------------------------------------------------
 
 int gds_stream_wait_cq(CUstream stream, struct gds_cq *cq, int flags)
 {
-        int retcode = 0;
-        int ret;
-        gds_wait_request_t request;
+    int retcode = 0;
+    int ret;
+    gds_wait_request_s request;
 
-        assert(cq);
-        assert(stream);
+    assert(cq);
+    assert(stream);
 
-        if (flags) {
-                retcode = EINVAL;
-                goto out;
+    if (flags) {
+        retcode = EINVAL;
+        goto out;
+    }
+
+    ret = gds_prepare_wait_cq_internal(cq, &request, flags);
+    if (ret) {
+        gds_err("error %d in gds_prepare_wait_cq\n", ret);
+        goto out;
+    }
+
+    ret = gds_stream_post_wait_cq_internal(stream, &request);
+    if (ret) {
+        gds_err("error %d in gds_stream_post_wait_cq_ex\n", ret);
+        int retcode2 = gds_abort_wait_cq(cq, &request);
+        if (retcode2) {
+            gds_err("nested error %d while aborting request\n", retcode2);
         }
-
-        ret = gds_prepare_wait_cq(cq, &request, flags);
-        if (ret) {
-                gds_err("error %d in gds_prepare_wait_cq\n", ret);
-                goto out;
-        }
-
-        ret = gds_stream_post_wait_cq(stream, &request);
-        if (ret) {
-                gds_err("error %d in gds_stream_post_wait_cq_ex\n", ret);
-                int retcode2 = gds_abort_wait_cq(cq, &request);
-                if (retcode2) {
-                        gds_err("nested error %d while aborting request\n", retcode2);
-                }
-                retcode = ret;
-                goto out;
-        }
+        retcode = ret;
+        goto out;
+    }
 
 out:
-	return retcode;
+    return retcode;
 }
 
 //-----------------------------------------------------------------------------
 
 int gds_post_wait_cq(struct gds_cq *cq, gds_wait_request_t *request, int flags)
 {
-        int retcode = 0;
+    int retcode = 0;
+    gds_wait_request_s *wait_request = to_gds_wait_request_s(request);
 
-        if (flags) {
-                retcode = EINVAL;
-                goto out;
-        }
+    if (flags) {
+        retcode = EINVAL;
+        goto out;
+    }
 
-        retcode = gds_abort_wait_cq(cq, request);
+    retcode = gds_abort_wait_cq(cq, wait_request);
 out:
-        return retcode;
+    free(wait_request);
+    request->handle = NULL;
+    return retcode;
 }
 
 //-----------------------------------------------------------------------------
@@ -547,335 +613,316 @@ static int get_wait_info(size_t n_descs, gds_descriptor_t *descs, size_t &n_wait
 
 static int calc_n_mem_ops(size_t n_descs, gds_descriptor_t *descs, size_t &n_mem_ops)
 {
-        int ret = 0;
-        n_mem_ops = 0;
-        size_t i;
-        for(i = 0; i < n_descs; ++i) {
-                gds_descriptor_t *desc = descs + i;
-                switch(desc->tag) {
-                case GDS_TAG_SEND:
-                        n_mem_ops += desc->send->commit.entries + 2; // extra space, ugly
-                        break;
-                case GDS_TAG_WAIT:
-                        n_mem_ops += desc->wait->peek.entries + 2; // ditto
-                        break;
-                case GDS_TAG_WAIT_VALUE32:
-                case GDS_TAG_WRITE_VALUE32:
-                case GDS_TAG_WRITE_MEMORY:
-                        n_mem_ops += 2; // ditto
-                        break;
-                default:
-                        gds_err("invalid tag\n");
-                        ret = EINVAL;
-                }
+    int ret = 0;
+    n_mem_ops = 0;
+    size_t i;
+    for(i = 0; i < n_descs; ++i) {
+        gds_descriptor_t *desc = descs + i;
+        switch(desc->tag) {
+            case GDS_TAG_SEND:
+                n_mem_ops += to_gds_send_request_s(&desc->send)->commit.entries + 2; // extra space, ugly
+                break;
+            case GDS_TAG_WAIT:
+                n_mem_ops += to_gds_wait_request_s(&desc->wait)->peek.entries + 2; // ditto
+                break;
+            case GDS_TAG_WAIT_VALUE32:
+            case GDS_TAG_WRITE_VALUE32:
+            case GDS_TAG_WRITE_MEMORY:
+                n_mem_ops += 2; // ditto
+                break;
+            default:
+                gds_err("invalid tag\n");
+                ret = EINVAL;
         }
-        return ret;
+    }
+    return ret;
 }
 
 int gds_stream_post_descriptors(CUstream stream, size_t n_descs, gds_descriptor_t *descs, int flags)
 {
-        size_t i;
-        int idx = 0;
-        int ret = 0;
-        int retcode = 0;
-        size_t n_mem_ops = 0;
-        size_t n_waits = 0;
-        size_t last_wait = 0;
-        bool move_flush = false;
-        gds_peer *peer = NULL;
-        gds_op_list_t params;
+    size_t i;
+    int idx = 0;
+    int ret = 0;
+    int retcode = 0;
+    size_t n_mem_ops = 0;
+    size_t n_waits = 0;
+    size_t last_wait = 0;
+    bool move_flush = false;
+    gds_peer *peer = NULL;
+    gds_op_list_t params;
+    int free_requests = !(flags & GDS_FLAG_INTERNAL_KEEP_REQUESTS);
 
+    // remove this flag before passing to other functions
+    flags &= ~GDS_FLAG_INTERNAL_KEEP_REQUESTS;
 
-        ret = calc_n_mem_ops(n_descs, descs, n_mem_ops);
-        if (ret) {
-                gds_err("error %d in calc_n_mem_ops\n", ret);
-                goto out;
-        }
+    ret = calc_n_mem_ops(n_descs, descs, n_mem_ops);
+    if (ret) {
+        gds_err("error %d in calc_n_mem_ops\n", ret);
+        goto out;
+    }
 
-        ret = get_wait_info(n_descs, descs, n_waits, last_wait);
-        if (ret) {
-                gds_err("error %d in get_wait_info\n", ret);
-                goto out;
-        }
+    ret = get_wait_info(n_descs, descs, n_waits, last_wait);
+    if (ret) {
+        gds_err("error %d in get_wait_info\n", ret);
+        goto out;
+    }
 
-        gds_dbg("n_descs=%zu n_waits=%zu n_mem_ops=%zu\n", n_descs, n_waits, n_mem_ops);
+    gds_dbg("n_descs=%zu n_waits=%zu n_mem_ops=%zu\n", n_descs, n_waits, n_mem_ops);
 
-        // move flush to last wait in the whole batch
-        if (n_waits && no_network_descs_after_entry(n_descs, descs, last_wait)) {
-                gds_dbg("optimizing FLUSH to last wait i=%zu\n", last_wait);
-                move_flush = true;
-        }
-        // alternatively, remove flush for wait is next op is a wait too
+    // move flush to last wait in the whole batch
+    if (n_waits && no_network_descs_after_entry(n_descs, descs, last_wait)) {
+        gds_dbg("optimizing FLUSH to last wait i=%zu\n", last_wait);
+        move_flush = true;
+    }
+    // alternatively, remove flush for wait is next op is a wait too
 
-        peer = peer_from_stream(stream);
-        if (!peer) {
-                return EINVAL;
-        }
+    peer = peer_from_stream(stream);
+    if (!peer) {
+        return EINVAL;
+    }
 
-        for(i = 0; i < n_descs; ++i) {
-                gds_descriptor_t *desc = descs + i;
-                switch(desc->tag) {
-                case GDS_TAG_SEND: {
-                        gds_send_request_t *sreq = desc->send;
-                        retcode = gds_post_ops(peer, sreq->commit.entries, sreq->commit.storage, params);
-                        if (retcode) {
-                                gds_err("error %d in gds_post_ops\n", retcode);
-                                ret = retcode;
-                                goto out;
-                        }
-                        break;
+    for(i = 0; i < n_descs; ++i) {
+        gds_descriptor_t *desc = descs + i;
+        switch(desc->tag) {
+            case GDS_TAG_SEND: {
+                gds_send_request_s *sreq = to_gds_send_request_s(&desc->send);
+                retcode = gds_post_ops(peer, sreq->commit.entries, sreq->commit.storage, params);
+                if (retcode) {
+                    gds_err("error %d in gds_post_ops\n", retcode);
+                    ret = retcode;
+                    goto out;
                 }
-                case GDS_TAG_WAIT: {
-                        gds_wait_request_t *wreq = desc->wait;
-                        int flags = 0;
-                        if (move_flush && i != last_wait) {
-                                gds_dbg("discarding FLUSH!\n");
-                                flags = GDS_POST_OPS_DISCARD_WAIT_FLUSH;
-                        }
-                        retcode = gds_post_ops(peer, wreq->peek.entries, wreq->peek.storage, params, flags);
-                        if (retcode) {
-                                gds_err("error %d in gds_post_ops\n", retcode);
-                                ret = retcode;
-                                goto out;
-                        }
-                        break;
+                break;
+            }
+            case GDS_TAG_WAIT: {
+                gds_wait_request_s *wreq = to_gds_wait_request_s(&desc->wait);
+                int flags = 0;
+                if (move_flush && i != last_wait) {
+                    gds_dbg("discarding FLUSH!\n");
+                    flags = GDS_POST_OPS_DISCARD_WAIT_FLUSH;
                 }
-                case GDS_TAG_WAIT_VALUE32:
-                        retcode = gds_fill_poll(peer, params, desc->wait32.ptr, desc->wait32.value, desc->wait32.cond_flags, desc->wait32.flags);
-                        if (retcode) {
-                                gds_err("error %d in gds_fill_poll\n", retcode);
-                                ret = retcode;
-                                goto out;
-                        }
-                        break;
-                case GDS_TAG_WRITE_VALUE32:
-                        retcode = gds_fill_poke(peer, params, desc->write32.ptr, desc->write32.value, desc->write32.flags);
-                        if (retcode) {
-                                gds_err("error %d in gds_fill_poke\n", retcode);
-                                ret = retcode;
-                                goto out;
-                        }
-                        break;
-                case GDS_TAG_WRITE_MEMORY:
-                        retcode = gds_fill_inlcpy(peer, params, desc->writemem.dest, desc->writemem.src, desc->writemem.count, desc->writemem.flags);
-                        if (retcode) {
-                                gds_err("error %d in gds_fill_inlcpy\n", retcode);
-                                ret = retcode;
-                                goto out;
-                        }
-                        break;
-                default:
-                        gds_err("invalid tag for %zu entry\n", i);
-                        ret = EINVAL;
-                        goto out;
-                        break;
+                retcode = gds_post_ops(peer, wreq->peek.entries, wreq->peek.storage, params, flags);
+                if (retcode) {
+                    gds_err("error %d in gds_post_ops\n", retcode);
+                    ret = retcode;
+                    goto out;
                 }
-        }
-        retcode = gds_stream_batch_ops(peer, stream, params, 0);
-        if (retcode) {
-                gds_err("error %d in gds_stream_batch_ops\n", retcode);
-                ret = retcode;
+                break;
+            }
+            case GDS_TAG_WAIT_VALUE32:
+                retcode = gds_fill_poll(peer, params, desc->wait32.ptr, desc->wait32.value, desc->wait32.cond_flags, desc->wait32.flags);
+                if (retcode) {
+                    gds_err("error %d in gds_fill_poll\n", retcode);
+                    ret = retcode;
+                    goto out;
+                }
+                break;
+            case GDS_TAG_WRITE_VALUE32:
+                retcode = gds_fill_poke(peer, params, desc->write32.ptr, desc->write32.value, desc->write32.flags);
+                if (retcode) {
+                    gds_err("error %d in gds_fill_poke\n", retcode);
+                    ret = retcode;
+                    goto out;
+                }
+                break;
+            case GDS_TAG_WRITE_MEMORY:
+                retcode = gds_fill_inlcpy(peer, params, desc->writemem.dest, desc->writemem.src, desc->writemem.count, desc->writemem.flags);
+                if (retcode) {
+                    gds_err("error %d in gds_fill_inlcpy\n", retcode);
+                    ret = retcode;
+                    goto out;
+                }
+                break;
+            default:
+                gds_err("invalid tag for %zu entry\n", i);
+                ret = EINVAL;
                 goto out;
+                break;
         }
+    }
+    retcode = gds_stream_batch_ops(peer, stream, params, 0);
+    if (retcode) {
+        gds_err("error %d in gds_stream_batch_ops\n", retcode);
+        ret = retcode;
+        goto out;
+    }
 
 out:
-        return ret;
+    if (free_requests) {
+        for(i = 0; i < n_descs; ++i) {
+            gds_descriptor_t *desc = descs + i;
+            if (desc->tag == GDS_TAG_SEND) {
+                free(desc->send.handle);
+                desc->send.handle = NULL;
+            }
+            else if (desc->tag == GDS_TAG_WAIT) {
+                free(desc->wait.handle);
+                desc->wait.handle = NULL;
+            }
+        }
+    }
+    return ret;
 }
 
 //-----------------------------------------------------------------------------
 
 int gds_post_descriptors(size_t n_descs, gds_descriptor_t *descs, int flags)
 {
-        size_t i;
-        int ret = 0;
-        int retcode = 0;
-        for(i = 0; i < n_descs; ++i) {
-                gds_descriptor_t *desc = descs + i;
-                switch(desc->tag) {
-                case GDS_TAG_SEND: {
-                        gds_dbg("desc[%zu] SEND\n", i);
-                        gds_send_request_t *sreq = desc->send;
-                        retcode = gds_post_ops_on_cpu(sreq->commit.entries, sreq->commit.storage, flags);
-                        if (retcode) {
-                                gds_err("error %d in gds_post_ops_on_cpu\n", retcode);
-                                ret = retcode;
-                                goto out;
-                        }
-                        break;
+    size_t i;
+    int ret = 0;
+    int retcode = 0;
+    for(i = 0; i < n_descs; ++i) {
+        gds_descriptor_t *desc = descs + i;
+        switch(desc->tag) {
+            case GDS_TAG_SEND: {
+                gds_dbg("desc[%zu] SEND\n", i);
+                gds_send_request_s *sreq = to_gds_send_request_s(&desc->send);
+                retcode = gds_post_ops_on_cpu(sreq->commit.entries, sreq->commit.storage, flags);
+                if (retcode) {
+                    gds_err("error %d in gds_post_ops_on_cpu\n", retcode);
+                    ret = retcode;
+                    goto out;
                 }
-                case GDS_TAG_WAIT: {
-                        gds_dbg("desc[%zu] WAIT\n", i);
-                        gds_wait_request_t *wreq = desc->wait;
-                        retcode = gds_post_ops_on_cpu(wreq->peek.entries, wreq->peek.storage, flags);
-                        if (retcode) {
-                                gds_err("error %d in gds_post_ops_on_cpu\n", retcode);
-                                ret = retcode;
-                                goto out;
-                        }
-                        break;
+                break;
+            }
+            case GDS_TAG_WAIT: {
+                gds_dbg("desc[%zu] WAIT\n", i);
+                gds_wait_request_s *wreq = to_gds_wait_request_s(&desc->wait);
+                retcode = gds_post_ops_on_cpu(wreq->peek.entries, wreq->peek.storage, flags);
+                if (retcode) {
+                    gds_err("error %d in gds_post_ops_on_cpu\n", retcode);
+                    ret = retcode;
+                    goto out;
                 }
-                case GDS_TAG_WAIT_VALUE32: {
-                        gds_dbg("desc[%zu] WAIT_VALUE32\n", i);
-                        uint32_t *ptr = desc->wait32.ptr;
-                        uint32_t value = desc->wait32.value;
-                        bool flush = false;
-                        if (desc->wait32.flags & GDS_WAIT_POST_FLUSH_REMOTE) {
-                                gds_err("GDS_WAIT_POST_FLUSH_REMOTE flag is not supported yet\n");
-                                flush = true;
-                        }
-                        gds_memory_type_t mem_type = (gds_memory_type_t)(desc->wait32.flags & GDS_MEMORY_MASK);
-                        switch(mem_type) {
-                        case GDS_MEMORY_GPU:
-                                // dereferencing ptr may fail if ptr points to CUDA device memory
-                        case GDS_MEMORY_HOST:
-                        case GDS_MEMORY_IO:
-                                break;
-                        default:
-                                gds_err("invalid memory type 0x%02x in WAIT_VALUE32\n", mem_type);
-                                ret = EINVAL;
-                                goto out;
-                                break;
-                        }
-                        bool done = false;
-                        do {
-                                uint32_t data = gds_atomic_get(ptr);
-                                switch(desc->wait32.cond_flags) {
-                                case GDS_WAIT_COND_GEQ:
-                                        done = ((int32_t)data - (int32_t)value >= 0);
-                                        break;
-                                case GDS_WAIT_COND_EQ:
-                                        done = (data == value);
-                                        break;
-                                case GDS_WAIT_COND_AND:
-                                        done = (data & value);
-                                        break;
-                                case GDS_WAIT_COND_NOR:
-                                        done = ~(data | value);
-                                        break;
-                                default:
-                                        gds_err("invalid condition flags 0x%02x in WAIT_VALUE32\n", desc->wait32.cond_flags);
-                                        goto out;
-                                        break;
-                                }
-                                if (done)
-                                        break;
-                                // TODO: more aggressive CPU relaxing needed here to avoid starving I/O fabric
-                                arch_cpu_relax();
-                        } while(true);
-                        break;
+                break;
+            }
+            case GDS_TAG_WAIT_VALUE32: {
+                gds_dbg("desc[%zu] WAIT_VALUE32\n", i);
+                uint32_t *ptr = desc->wait32.ptr;
+                uint32_t value = desc->wait32.value;
+                bool flush = false;
+                if (desc->wait32.flags & GDS_WAIT_POST_FLUSH_REMOTE) {
+                    gds_err("GDS_WAIT_POST_FLUSH_REMOTE flag is not supported yet\n");
+                    flush = true;
                 }
-                case GDS_TAG_WRITE_VALUE32: {
-                        gds_dbg("desc[%zu] WRITE_VALUE32\n", i);
-                        uint32_t *ptr = desc->write32.ptr;
-                        uint32_t value = desc->write32.value;
-                        gds_memory_type_t mem_type = (gds_memory_type_t)(desc->write32.flags & GDS_MEMORY_MASK);
-                        switch(mem_type) {
-                        case GDS_MEMORY_GPU:
-                                // dereferencing ptr may fail if ptr points to CUDA device memory
-                        case GDS_MEMORY_HOST:
-                        case GDS_MEMORY_IO:
-                                break;
-                        default:
-                                gds_err("invalid memory type 0x%02x in WRITE_VALUE32\n", mem_type);
-                                ret = EINVAL;
-                                goto out;
-                                break;
-                        }
-                        bool barrier = (desc->write32.flags & GDS_WRITE_PRE_BARRIER_SYS);
-                        if (barrier)
-                                wmb();
-                        gds_atomic_set(ptr, value);
+                gds_memory_type_t mem_type = (gds_memory_type_t)(desc->wait32.flags & GDS_MEMORY_MASK);
+                switch(mem_type) {
+                    case GDS_MEMORY_GPU:
+                        // dereferencing ptr may fail if ptr points to CUDA device memory
+                    case GDS_MEMORY_HOST:
+                    case GDS_MEMORY_IO:
                         break;
-                }
-                case GDS_TAG_WRITE_MEMORY: {
-                        void *dest = desc->writemem.dest;
-                        const void *src = desc->writemem.src;
-                        size_t nbytes = desc->writemem.count;
-                        bool barrier = (desc->writemem.flags & GDS_WRITE_MEMORY_POST_BARRIER_SYS);
-                        gds_memory_type_t mem_type = memtype_from_flags(desc->writemem.flags);
-                        gds_dbg("desc[%zu] WRITE_MEMORY dest=%p src=%p len=%zu memtype=%02x\n", i, dest, src, nbytes, mem_type);
-                        switch(mem_type) {
-                        case GDS_MEMORY_GPU:
-                        case GDS_MEMORY_HOST:
-                                memcpy(dest, src, nbytes);
-                                break;
-                        case GDS_MEMORY_IO:
-                                assert(nbytes % sizeof(uint64_t));
-                                assert(((unsigned long)dest & 0x7) == 0);
-                                gds_bf_copy((uint64_t*)dest, (uint64_t*)src, nbytes);
-                                break;
-                        default:
-                                assert(!"invalid mem type");
-                                break;
-                        }
-                        if (barrier)
-                                wmb();
-                        break;
-                }
-                default:
-                        gds_err("invalid tag for %zu entry\n", i);
+                    default:
+                        gds_err("invalid memory type 0x%02x in WAIT_VALUE32\n", mem_type);
                         ret = EINVAL;
                         goto out;
                         break;
                 }
+                bool done = false;
+                do {
+                    uint32_t data = gds_atomic_get(ptr);
+                    switch(desc->wait32.cond_flags) {
+                        case GDS_WAIT_COND_GEQ:
+                            done = ((int32_t)data - (int32_t)value >= 0);
+                            break;
+                        case GDS_WAIT_COND_EQ:
+                            done = (data == value);
+                            break;
+                        case GDS_WAIT_COND_AND:
+                            done = (data & value);
+                            break;
+                        case GDS_WAIT_COND_NOR:
+                            done = ~(data | value);
+                            break;
+                        default:
+                            gds_err("invalid condition flags 0x%02x in WAIT_VALUE32\n", desc->wait32.cond_flags);
+                            goto out;
+                            break;
+                    }
+                    if (done)
+                        break;
+                    // TODO: more aggressive CPU relaxing needed here to avoid starving I/O fabric
+                    arch_cpu_relax();
+                } while(true);
+                break;
+            }
+            case GDS_TAG_WRITE_VALUE32: {
+                gds_dbg("desc[%zu] WRITE_VALUE32\n", i);
+                uint32_t *ptr = desc->write32.ptr;
+                uint32_t value = desc->write32.value;
+                gds_memory_type_t mem_type = (gds_memory_type_t)(desc->write32.flags & GDS_MEMORY_MASK);
+                switch(mem_type) {
+                    case GDS_MEMORY_GPU:
+                        // dereferencing ptr may fail if ptr points to CUDA device memory
+                    case GDS_MEMORY_HOST:
+                    case GDS_MEMORY_IO:
+                        break;
+                    default:
+                        gds_err("invalid memory type 0x%02x in WRITE_VALUE32\n", mem_type);
+                        ret = EINVAL;
+                        goto out;
+                        break;
+                }
+                bool barrier = (desc->write32.flags & GDS_WRITE_PRE_BARRIER_SYS);
+                if (barrier)
+                    wmb();
+                gds_atomic_set(ptr, value);
+                break;
+            }
+            case GDS_TAG_WRITE_MEMORY: {
+                void *dest = desc->writemem.dest;
+                const void *src = desc->writemem.src;
+                size_t nbytes = desc->writemem.count;
+                bool barrier = (desc->writemem.flags & GDS_WRITE_MEMORY_POST_BARRIER_SYS);
+                gds_memory_type_t mem_type = memtype_from_flags(desc->writemem.flags);
+                gds_dbg("desc[%zu] WRITE_MEMORY dest=%p src=%p len=%zu memtype=%02x\n", i, dest, src, nbytes, mem_type);
+                switch(mem_type) {
+                    case GDS_MEMORY_GPU:
+                    case GDS_MEMORY_HOST:
+                        memcpy(dest, src, nbytes);
+                        break;
+                    case GDS_MEMORY_IO:
+                        assert(nbytes % sizeof(uint64_t));
+                        assert(((unsigned long)dest & 0x7) == 0);
+                        gds_bf_copy((uint64_t*)dest, (uint64_t*)src, nbytes);
+                        break;
+                    default:
+                        assert(!"invalid mem type");
+                        break;
+                }
+                if (barrier)
+                    wmb();
+                break;
+            }
+            default:
+                gds_err("invalid tag for %zu entry\n", i);
+                ret = EINVAL;
+                goto out;
+                break;
         }
+    }
 out:
-        return ret;
-}
-
-//-----------------------------------------------------------------------------
-
-int gds_alloc_send_request(gds_send_request_t **request, int num)
-{
-    if (num < 0)
-        return -EINVAL;
-
-    *request = (gds_send_request_t *)calloc(num, sizeof(gds_send_request_t));
-
-    if (*request == NULL && num != 0)
-        return -ENOMEM;
-
-    return 0;
-}
-
-//-----------------------------------------------------------------------------
-
-void gds_free_send_request(gds_send_request_t *request)
-{
-    if (request)
-        free(request);
-}
-
-//-----------------------------------------------------------------------------
-
-int gds_alloc_wait_request(gds_wait_request_t **request, int num)
-{
-    if (num < 0)
-        return -EINVAL;
-
-    *request = (gds_wait_request_t *)calloc(num, sizeof(gds_wait_request_t));
-
-    if (*request == NULL && num != 0)
-        return -ENOMEM;
-
-    return 0;
-}
-
-//-----------------------------------------------------------------------------
-
-void gds_free_wait_request(gds_wait_request_t *request)
-{
-    if (request)
-        free(request);
+    for(i = 0; i < n_descs; ++i) {
+        gds_descriptor_t *desc = descs + i;
+        if (desc->tag == GDS_TAG_SEND) {
+            free(desc->send.handle);
+            desc->send.handle = NULL;
+        }
+        else if (desc->tag == GDS_TAG_WAIT) {
+            free(desc->wait.handle);
+            desc->wait.handle = NULL;
+        }
+    }
+    return ret;
 }
 
 //-----------------------------------------------------------------------------
 
 /*
  * Local variables:
- *  c-indent-level: 8
- *  c-basic-offset: 8
- *  tab-width: 8
+ *  c-indent-level: 4
+ *  c-basic-offset: 4
+ *  tab-width: 4
  *  indent-tabs-mode: nil
  * End:
  */

--- a/src/apis.cpp
+++ b/src/apis.cpp
@@ -179,14 +179,14 @@ int gds_prepare_send(struct gds_qp *qp, gds_send_wr *p_ewr,
         gds_init_send_info(request);
         assert(qp);
         assert(qp->qp);
-        ret = ibv_exp_post_send(qp->qp, p_ewr, bad_ewr);
+        ret = ibv_post_send(qp->qp, p_ewr, bad_ewr);
         if (ret) {
 
                 if (ret == ENOMEM) {
                         // out of space error can happen too often to report
-                        gds_dbg("ENOMEM error %d in ibv_exp_post_send\n", ret);
+                        gds_dbg("ENOMEM error %d in ibv_post_send\n", ret);
                 } else {
-                        gds_err("error %d in ibv_exp_post_send\n", ret);
+                        gds_err("error %d in ibv_post_send\n", ret);
                 }
                 goto out;
         }

--- a/src/apis.cpp
+++ b/src/apis.cpp
@@ -34,15 +34,6 @@
 #include <assert.h>
 #include <inttypes.h>
 
-//#include <map>
-//#include <algorithm>
-//#include <string>
-//using namespace std;
-
-//#include <cuda.h>
-//#include <infiniband/verbs_exp.h>
-//#include <gdrapi.h>
-
 #include "gdsync.h"
 #include "gdsync/tools.h"
 #include "objs.hpp"
@@ -97,10 +88,7 @@ static int gds_rollback_qp(gds_qp_t *qp, gds_send_request_s *send_info, enum ibv
         assert(qp);
         assert(qp->qp);
         assert(send_info);
-        if(
-                        flag != IBV_EXP_ROLLBACK_ABORT_UNCOMMITED && 
-                        flag != IBV_EXP_ROLLBACK_ABORT_LATE
-          )
+        if (flag != IBV_EXP_ROLLBACK_ABORT_UNCOMMITED && flag != IBV_EXP_ROLLBACK_ABORT_LATE)
         {
                 gds_err("erroneous ibv_exp_rollback_flags flag input value\n");
                 ret=EINVAL;
@@ -115,7 +103,7 @@ static int gds_rollback_qp(gds_qp_t *qp, gds_send_request_s *send_info, enum ibv
         rollback.comp_mask = 0;
         gds_warn("Need to rollback WQE %lx\n", rollback.rollback_id);
         ret = ibv_exp_rollback_qp(qp->qp, &rollback);
-        if(ret)
+        if (ret)
                 gds_err("error %d in ibv_exp_rollback_qp\n", ret);
 
 out:
@@ -179,78 +167,78 @@ out:
 //-----------------------------------------------------------------------------
 
 int gds_prepare_send(gds_qp_t *qp, gds_send_wr *p_ewr, 
-                     gds_send_wr **bad_ewr, 
-                     gds_send_request_t *request)
+                gds_send_wr **bad_ewr, 
+                gds_send_request_t *request)
 {
-    int ret = 0;
-    gds_send_request_s *send_request = NULL;
-    assert(qp);
-    assert(qp->qp);
+        int ret = 0;
+        gds_send_request_s *send_request = NULL;
+        assert(qp);
+        assert(qp->qp);
 
-    send_request = (gds_send_request_s *)malloc(sizeof(gds_send_request_s));
-    if (send_request == NULL) {
-        gds_err("out of memory in gds_prepare_send\n");
-        return ENOMEM;
-    }
-
-    gds_init_send_info(send_request);
-    ret = ibv_post_send(qp->qp, p_ewr, bad_ewr);
-    if (ret) {
-        if (ret == ENOMEM) {
-            // out of space error can happen too often to report
-            gds_dbg("ENOMEM error %d in ibv_post_send\n", ret);
-        } else {
-            gds_err("error %d in ibv_post_send\n", ret);
+        send_request = (gds_send_request_s *)malloc(sizeof(gds_send_request_s));
+        if (send_request == NULL) {
+                gds_err("out of memory in gds_prepare_send\n");
+                return ENOMEM;
         }
-        goto out;
-    }
 
-    ret = ibv_exp_peer_commit_qp(qp->qp, &send_request->commit);
-    if (ret) {
-        gds_err("error %d in ibv_exp_peer_commit_qp\n", ret);
-        goto out;
-    }
+        gds_init_send_info(send_request);
+        ret = ibv_post_send(qp->qp, p_ewr, bad_ewr);
+        if (ret) {
+                if (ret == ENOMEM) {
+                        // out of space error can happen too often to report
+                        gds_dbg("ENOMEM error %d in ibv_post_send\n", ret);
+                } else {
+                        gds_err("error %d in ibv_post_send\n", ret);
+                }
+                goto out;
+        }
+
+        ret = ibv_exp_peer_commit_qp(qp->qp, &send_request->commit);
+        if (ret) {
+                gds_err("error %d in ibv_exp_peer_commit_qp\n", ret);
+                goto out;
+        }
 
 out:
-    if (ret != 0 && send_request != NULL) {
-        free(send_request);
-        return ret;
-    }
+        if (ret != 0 && send_request != NULL) {
+                free(send_request);
+                return ret;
+        }
 
-    if (ret == 0)
-        request->handle = (void *)send_request;
-    
-    return ret;
+        if (ret == 0)
+                request->handle = (void *)send_request;
+
+        return ret;
 }
 
 //-----------------------------------------------------------------------------
 
 int gds_stream_queue_send(CUstream stream, gds_qp_t *qp, gds_send_wr *p_ewr, gds_send_wr **bad_ewr)
 {
-    int ret = 0, ret_roll = 0;
-    gds_send_request_t send_info;
-    gds_descriptor_t descs[1];
+        int ret = 0, ret_roll = 0;
+        gds_send_request_t send_info;
+        gds_descriptor_t descs[1];
 
-    assert(qp);
-    assert(p_ewr);
+        assert(qp);
+        assert(p_ewr);
 
-    ret = gds_prepare_send(qp, p_ewr, bad_ewr, &send_info);
-    if (ret) {
-        gds_err("error %d in gds_prepare_send\n", ret);
-        goto out;
-    }
+        ret = gds_prepare_send(qp, p_ewr, bad_ewr, &send_info);
+        if (ret) {
+                gds_err("error %d in gds_prepare_send\n", ret);
+                goto out;
+        }
 
-    descs[0].tag = GDS_TAG_SEND;
-    descs[0].send = &send_info;
+        descs[0].tag = GDS_TAG_SEND;
+        descs[0].send = &send_info;
 
-    ret = gds_stream_post_descriptors(stream, 1, descs, 0);
-    if (ret) {
-        gds_err("error %d in gds_stream_post_descriptors\n", ret);
-        goto out;
-    }
+        ret = gds_stream_post_descriptors(stream, 1, descs, 0);
+        if (ret) {
+                gds_err("error %d in gds_stream_post_descriptors\n", ret);
+                goto out;
+        }
 
 out:
-    return ret;
+        return ret;
 }
 
 //-----------------------------------------------------------------------------
@@ -269,203 +257,202 @@ int gds_stream_post_send(CUstream stream, gds_send_request_t *request)
 
 int gds_stream_post_send_all(CUstream stream, int count, gds_send_request_t *request)
 {
-    int ret = 0, k = 0;
-    gds_descriptor_t * descs = NULL;
+        int ret = 0, k = 0;
+        gds_descriptor_t * descs = NULL;
 
-    assert(request);
-    assert(count);
+        assert(request);
+        assert(count);
 
-    descs = (gds_descriptor_t *)calloc(count, sizeof(gds_descriptor_t));
-    if(!descs)
-    {
-        gds_err("Calloc for %d elements\n", count);
-        ret = ENOMEM;
-        goto out;
-    }
+        descs = (gds_descriptor_t *)calloc(count, sizeof(gds_descriptor_t));
+        if (!descs) {
+                gds_err("Calloc for %d elements\n", count);
+                ret = ENOMEM;
+                goto out;
+        }
 
-    for (k = 0; k < count; k++) {
-        descs[k].tag = GDS_TAG_SEND;
-        descs[k].send = &request[k];
-    }
+        for (k = 0; k < count; k++) {
+                descs[k].tag = GDS_TAG_SEND;
+                descs[k].send = &request[k];
+        }
 
-    ret = gds_stream_post_descriptors(stream, count, descs, 0);
-    if (ret) {
-        gds_err("error %d in gds_stream_post_descriptors\n", ret);
-        goto out;
-    }
+        ret = gds_stream_post_descriptors(stream, count, descs, 0);
+        if (ret) {
+                gds_err("error %d in gds_stream_post_descriptors\n", ret);
+                goto out;
+        }
 
 out:
-    if (descs) 
-        free(descs);
-    return ret;
+        if (descs) 
+                free(descs);
+        return ret;
 }
 
 //-----------------------------------------------------------------------------
 
 int gds_prepare_wait_cq(gds_cq_t *cq, gds_wait_request_t *request, int flags)
 {
-    int retcode = 0;
-    gds_wait_request_s *wait_request = NULL;
+        int retcode = 0;
+        gds_wait_request_s *wait_request = NULL;
 
-    if (flags != 0) {
-        gds_err("invalid flags != 0\n");
-        return EINVAL;
-    }
+        if (flags != 0) {
+                gds_err("invalid flags != 0\n");
+                return EINVAL;
+        }
 
-    wait_request = (gds_wait_request_s *)malloc(sizeof(gds_wait_request_s));
-    if (wait_request == NULL) {
-        gds_err("out of memory in gds_prepare_wait_cq\n");
-        return ENOMEM;
-    }
+        wait_request = (gds_wait_request_s *)malloc(sizeof(gds_wait_request_s));
+        if (wait_request == NULL) {
+                gds_err("out of memory in gds_prepare_wait_cq\n");
+                return ENOMEM;
+        }
 
-    gds_init_wait_request(wait_request, cq->curr_offset++);
+        gds_init_wait_request(wait_request, cq->curr_offset++);
 
-    retcode = ibv_exp_peer_peek_cq(cq->cq, &wait_request->peek);
-    if (retcode == -ENOSPC) {
-        // TODO: handle too few entries
-        gds_err("not enough ops in peer_peek_cq\n");
-        goto out;
-    } else if (retcode) {
-        gds_err("error %d in peer_peek_cq\n", retcode);
-        goto out;
-    }
-    //gds_dump_wait_request(wait_request, 1);
+        retcode = ibv_exp_peer_peek_cq(cq->cq, &wait_request->peek);
+        if (retcode == -ENOSPC) {
+                // TODO: handle too few entries
+                gds_err("not enough ops in peer_peek_cq\n");
+                goto out;
+        } else if (retcode) {
+                gds_err("error %d in peer_peek_cq\n", retcode);
+                goto out;
+        }
+        //gds_dump_wait_request(wait_request, 1);
 
 out:
-    if (retcode != 0 && wait_request != NULL) {
-        free(wait_request);
+        if (retcode != 0 && wait_request != NULL) {
+                free(wait_request);
+                return retcode;
+        }
+
+        if (retcode == 0)
+                request->handle = (void *)wait_request;
+
         return retcode;
-    }
-
-    if (retcode == 0)
-        request->handle = (void *)wait_request;
-
-    return retcode;
 }
 
 //-----------------------------------------------------------------------------
 
 int gds_append_wait_cq(gds_wait_request_t *request, uint32_t *dw, uint32_t val)
 {
-    int ret = 0;
-    gds_wait_request_s *wait_request = to_gds_wait_request_s(request);
-    unsigned MAX_NUM_ENTRIES = sizeof(wait_request->wr) / sizeof(wait_request->wr[0]);
-    unsigned n = wait_request->peek.entries;
-    struct peer_op_wr *wr = wait_request->peek.storage;
+        int ret = 0;
+        gds_wait_request_s *wait_request = to_gds_wait_request_s(request);
+        unsigned MAX_NUM_ENTRIES = sizeof(wait_request->wr) / sizeof(wait_request->wr[0]);
+        unsigned n = wait_request->peek.entries;
+        struct peer_op_wr *wr = wait_request->peek.storage;
 
-    if (n + 1 > MAX_NUM_ENTRIES) {
-        gds_err("no space left to stuff a poke\n");
-        ret = ENOMEM;
-        goto out;
-    }
+        if (n + 1 > MAX_NUM_ENTRIES) {
+                gds_err("no space left to stuff a poke\n");
+                ret = ENOMEM;
+                goto out;
+        }
 
-    // at least 1 op
-    assert(n);
-    assert(wr);
+        // at least 1 op
+        assert(n);
+        assert(wr);
 
-    for (; n; --n) wr = wr->next;
-    assert(wr);
+        for (; n; --n) wr = wr->next;
+        assert(wr);
 
-    wr->type = IBV_EXP_PEER_OP_STORE_DWORD;
-    wr->wr.dword_va.data = val;
-    wr->wr.dword_va.target_id = 0; // direct mapping, offset IS the address
-    wr->wr.dword_va.offset = (ptrdiff_t)(dw-(uint32_t*)0);
+        wr->type = IBV_EXP_PEER_OP_STORE_DWORD;
+        wr->wr.dword_va.data = val;
+        wr->wr.dword_va.target_id = 0; // direct mapping, offset IS the address
+        wr->wr.dword_va.offset = (ptrdiff_t)(dw-(uint32_t*)0);
 
-    ++wait_request->peek.entries;
+        ++wait_request->peek.entries;
 
 out:
-    return ret;
+        return ret;
 }
 
 //-----------------------------------------------------------------------------
 
 int gds_stream_post_wait_cq(CUstream stream, gds_wait_request_t *request)
 {
-    return gds_stream_post_wait_cq_multi(stream, 1, request, NULL, 0);
+        return gds_stream_post_wait_cq_multi(stream, 1, request, NULL, 0);
 }
 
 //-----------------------------------------------------------------------------
 
 int gds_stream_post_wait_cq_all(CUstream stream, int count, gds_wait_request_t *requests)
 {
-	return gds_stream_post_wait_cq_multi(stream, count, requests, NULL, 0);
+        return gds_stream_post_wait_cq_multi(stream, count, requests, NULL, 0);
 }
 
 //-----------------------------------------------------------------------------
 
 static int gds_abort_wait_cq(gds_cq_t *cq, gds_wait_request_s *request)
 {
-    assert(cq);
-    assert(request);
-    struct ibv_exp_peer_abort_peek abort_ctx;
-    abort_ctx.peek_id = request->peek.peek_id;
-    abort_ctx.comp_mask = 0;
-    return ibv_exp_peer_abort_peek_cq(cq->cq, &abort_ctx);
+        assert(cq);
+        assert(request);
+        struct ibv_exp_peer_abort_peek abort_ctx;
+        abort_ctx.peek_id = request->peek.peek_id;
+        abort_ctx.comp_mask = 0;
+        return ibv_exp_peer_abort_peek_cq(cq->cq, &abort_ctx);
 }
 
 //-----------------------------------------------------------------------------
 
 int gds_stream_wait_cq(CUstream stream, gds_cq_t *cq, int flags)
 {
-    int retcode = 0;
-    int ret;
-    gds_wait_request_s *wreq;
+        int retcode = 0;
+        int ret;
+        gds_wait_request_s *wreq;
 
-    gds_wait_request_t request;
+        gds_wait_request_t request;
 
-    assert(cq);
-    assert(stream);
+        assert(cq);
+        assert(stream);
 
-    request.handle = NULL;
+        request.handle = NULL;
 
-    if (flags) {
-        retcode = EINVAL;
-        goto out;
-    }
-
-    ret = gds_prepare_wait_cq(cq, &request, flags);
-    if (ret) {
-        gds_err("error %d in gds_prepare_wait_cq\n", ret);
-        goto out;
-    }
-
-    wreq = to_gds_wait_request_s(&request);
-    wreq->flags = GDS_FLAG_INTERNAL_KEEP_REQUESTS;
-
-    ret = gds_stream_post_wait_cq(stream, &request);
-    if (ret) {
-        gds_err("error %d in gds_stream_post_wait_cq_ex\n", ret);
-        int retcode2 = gds_abort_wait_cq(cq, wreq);
-        if (retcode2) {
-            gds_err("nested error %d while aborting request\n", retcode2);
+        if (flags) {
+                retcode = EINVAL;
+                goto out;
         }
-        retcode = ret;
-        goto out;
-    }
+
+        ret = gds_prepare_wait_cq(cq, &request, flags);
+        if (ret) {
+                gds_err("error %d in gds_prepare_wait_cq\n", ret);
+                goto out;
+        }
+
+        wreq = to_gds_wait_request_s(&request);
+        wreq->flags = GDS_FLAG_INTERNAL_KEEP_REQUESTS;
+
+        ret = gds_stream_post_wait_cq(stream, &request);
+        if (ret) {
+                gds_err("error %d in gds_stream_post_wait_cq_ex\n", ret);
+                int retcode2 = gds_abort_wait_cq(cq, wreq);
+                if (retcode2) {
+                        gds_err("nested error %d while aborting request\n", retcode2);
+                }
+                retcode = ret;
+                goto out;
+        }
 
 out:
-    if (request.handle != NULL)
-        free(request.handle);
-    return retcode;
+        if (request.handle != NULL)
+                free(request.handle);
+        return retcode;
 }
 
 //-----------------------------------------------------------------------------
 
 int gds_post_wait_cq(gds_cq_t *cq, gds_wait_request_t *request, int flags)
 {
-    int retcode = 0;
-    gds_wait_request_s *wait_request = to_gds_wait_request_s(request);
+        int retcode = 0;
+        gds_wait_request_s *wait_request = to_gds_wait_request_s(request);
 
-    if (flags) {
-        retcode = EINVAL;
-        goto out;
-    }
+        if (flags) {
+                retcode = EINVAL;
+                goto out;
+        }
 
-    retcode = gds_abort_wait_cq(cq, wait_request);
+        retcode = gds_abort_wait_cq(cq, wait_request);
 out:
-    free(wait_request);
-    request->handle = NULL;
-    return retcode;
+        free(wait_request);
+        request->handle = NULL;
+        return retcode;
 }
 
 //-----------------------------------------------------------------------------
@@ -476,7 +463,7 @@ int gds_prepare_wait_value32(gds_wait_value32_t *desc, uint32_t *ptr, uint32_t v
         assert(desc);
 
         gds_dbg("desc=%p ptr=%p value=0x%08x cond_flags=0x%x flags=0x%x\n",
-                desc, ptr, value, cond_flags, flags);
+                        desc, ptr, value, cond_flags, flags);
 
         if (flags & ~(GDS_WAIT_POST_FLUSH_REMOTE|GDS_MEMORY_MASK)) {
                 gds_err("invalid flags\n");
@@ -557,17 +544,17 @@ static bool no_network_descs_after_entry(size_t n_descs, gds_descriptor_t *descs
         for(i = idx+1; i < n_descs; ++i) {
                 gds_descriptor_t *desc = descs + i;
                 switch(desc->tag) {
-                case GDS_TAG_SEND:
-                case GDS_TAG_WAIT:
-                        ret = false;
-                        goto out;
-                case GDS_TAG_WAIT_VALUE32:
-                case GDS_TAG_WRITE_VALUE32:
-                        break;
-                default:
-                        gds_err("invalid tag\n");
-                        ret = EINVAL;
-                        goto out;
+                        case GDS_TAG_SEND:
+                        case GDS_TAG_WAIT:
+                                ret = false;
+                                goto out;
+                        case GDS_TAG_WAIT_VALUE32:
+                        case GDS_TAG_WRITE_VALUE32:
+                                break;
+                        default:
+                                gds_err("invalid tag\n");
+                                ret = EINVAL;
+                                goto out;
                 }
         }
 out:
@@ -581,18 +568,18 @@ static int get_wait_info(size_t n_descs, gds_descriptor_t *descs, size_t &n_wait
         for(i = 0; i < n_descs; ++i) {
                 gds_descriptor_t *desc = descs + i;
                 switch(desc->tag) {
-                case GDS_TAG_WAIT:
-                        ++n_waits;
-                        last_wait = i;
-                        break;
-                case GDS_TAG_SEND:
-                case GDS_TAG_WAIT_VALUE32:
-                case GDS_TAG_WRITE_VALUE32:
-                case GDS_TAG_WRITE_MEMORY:
-                        break;
-                default:
-                        gds_err("invalid tag\n");
-                        ret = EINVAL;
+                        case GDS_TAG_WAIT:
+                                ++n_waits;
+                                last_wait = i;
+                                break;
+                        case GDS_TAG_SEND:
+                        case GDS_TAG_WAIT_VALUE32:
+                        case GDS_TAG_WRITE_VALUE32:
+                        case GDS_TAG_WRITE_MEMORY:
+                                break;
+                        default:
+                                gds_err("invalid tag\n");
+                                ret = EINVAL;
                 }
         }
         return ret;
@@ -600,318 +587,318 @@ static int get_wait_info(size_t n_descs, gds_descriptor_t *descs, size_t &n_wait
 
 static int calc_n_mem_ops(size_t n_descs, gds_descriptor_t *descs, size_t &n_mem_ops)
 {
-    int ret = 0;
-    n_mem_ops = 0;
-    size_t i;
-    for(i = 0; i < n_descs; ++i) {
-        gds_descriptor_t *desc = descs + i;
-        switch(desc->tag) {
-            case GDS_TAG_SEND:
-                n_mem_ops += to_gds_send_request_s(desc->send)->commit.entries + 2; // extra space, ugly
-                break;
-            case GDS_TAG_WAIT:
-                n_mem_ops += to_gds_wait_request_s(desc->wait)->peek.entries + 2; // ditto
-                break;
-            case GDS_TAG_WAIT_VALUE32:
-            case GDS_TAG_WRITE_VALUE32:
-            case GDS_TAG_WRITE_MEMORY:
-                n_mem_ops += 2; // ditto
-                break;
-            default:
-                gds_err("invalid tag\n");
-                ret = EINVAL;
+        int ret = 0;
+        n_mem_ops = 0;
+        size_t i;
+        for(i = 0; i < n_descs; ++i) {
+                gds_descriptor_t *desc = descs + i;
+                switch(desc->tag) {
+                        case GDS_TAG_SEND:
+                                n_mem_ops += to_gds_send_request_s(desc->send)->commit.entries + 2; // extra space, ugly
+                                break;
+                        case GDS_TAG_WAIT:
+                                n_mem_ops += to_gds_wait_request_s(desc->wait)->peek.entries + 2; // ditto
+                                break;
+                        case GDS_TAG_WAIT_VALUE32:
+                        case GDS_TAG_WRITE_VALUE32:
+                        case GDS_TAG_WRITE_MEMORY:
+                                n_mem_ops += 2; // ditto
+                                break;
+                        default:
+                                gds_err("invalid tag\n");
+                                ret = EINVAL;
+                }
         }
-    }
-    return ret;
+        return ret;
 }
 
 int gds_stream_post_descriptors(CUstream stream, size_t n_descs, gds_descriptor_t *descs, int flags)
 {
-    size_t i;
-    int idx = 0;
-    int ret = 0;
-    int retcode = 0;
-    size_t n_mem_ops = 0;
-    size_t n_waits = 0;
-    size_t last_wait = 0;
-    bool move_flush = false;
-    gds_peer *peer = NULL;
-    gds_op_list_t params;
+        size_t i;
+        int idx = 0;
+        int ret = 0;
+        int retcode = 0;
+        size_t n_mem_ops = 0;
+        size_t n_waits = 0;
+        size_t last_wait = 0;
+        bool move_flush = false;
+        gds_peer *peer = NULL;
+        gds_op_list_t params;
 
-    ret = calc_n_mem_ops(n_descs, descs, n_mem_ops);
-    if (ret) {
-        gds_err("error %d in calc_n_mem_ops\n", ret);
-        goto out;
-    }
-
-    ret = get_wait_info(n_descs, descs, n_waits, last_wait);
-    if (ret) {
-        gds_err("error %d in get_wait_info\n", ret);
-        goto out;
-    }
-
-    gds_dbg("n_descs=%zu n_waits=%zu n_mem_ops=%zu\n", n_descs, n_waits, n_mem_ops);
-
-    // move flush to last wait in the whole batch
-    if (n_waits && no_network_descs_after_entry(n_descs, descs, last_wait)) {
-        gds_dbg("optimizing FLUSH to last wait i=%zu\n", last_wait);
-        move_flush = true;
-    }
-    // alternatively, remove flush for wait is next op is a wait too
-
-    peer = peer_from_stream(stream);
-    if (!peer) {
-        return EINVAL;
-    }
-
-    for(i = 0; i < n_descs; ++i) {
-        gds_descriptor_t *desc = descs + i;
-        switch(desc->tag) {
-            case GDS_TAG_SEND: {
-                gds_send_request_s *sreq = to_gds_send_request_s(desc->send);
-                retcode = gds_post_ops(peer, sreq->commit.entries, sreq->commit.storage, params);
-                if (retcode) {
-                    gds_err("error %d in gds_post_ops\n", retcode);
-                    ret = retcode;
-                    goto out;
-                }
-                break;
-            }
-            case GDS_TAG_WAIT: {
-                gds_wait_request_s *wreq = to_gds_wait_request_s(desc->wait);
-                int flags = 0;
-                if (move_flush && i != last_wait) {
-                    gds_dbg("discarding FLUSH!\n");
-                    flags = GDS_POST_OPS_DISCARD_WAIT_FLUSH;
-                }
-                retcode = gds_post_ops(peer, wreq->peek.entries, wreq->peek.storage, params, flags);
-                if (retcode) {
-                    gds_err("error %d in gds_post_ops\n", retcode);
-                    ret = retcode;
-                    goto out;
-                }
-                break;
-            }
-            case GDS_TAG_WAIT_VALUE32:
-                retcode = gds_fill_poll(peer, params, desc->wait32.ptr, desc->wait32.value, desc->wait32.cond_flags, desc->wait32.flags);
-                if (retcode) {
-                    gds_err("error %d in gds_fill_poll\n", retcode);
-                    ret = retcode;
-                    goto out;
-                }
-                break;
-            case GDS_TAG_WRITE_VALUE32:
-                retcode = gds_fill_poke(peer, params, desc->write32.ptr, desc->write32.value, desc->write32.flags);
-                if (retcode) {
-                    gds_err("error %d in gds_fill_poke\n", retcode);
-                    ret = retcode;
-                    goto out;
-                }
-                break;
-            case GDS_TAG_WRITE_MEMORY:
-                retcode = gds_fill_inlcpy(peer, params, desc->writemem.dest, desc->writemem.src, desc->writemem.count, desc->writemem.flags);
-                if (retcode) {
-                    gds_err("error %d in gds_fill_inlcpy\n", retcode);
-                    ret = retcode;
-                    goto out;
-                }
-                break;
-            default:
-                gds_err("invalid tag for %zu entry\n", i);
-                ret = EINVAL;
+        ret = calc_n_mem_ops(n_descs, descs, n_mem_ops);
+        if (ret) {
+                gds_err("error %d in calc_n_mem_ops\n", ret);
                 goto out;
-                break;
         }
-    }
-    retcode = gds_stream_batch_ops(peer, stream, params, 0);
-    if (retcode) {
-        gds_err("error %d in gds_stream_batch_ops\n", retcode);
-        ret = retcode;
-        goto out;
-    }
+
+        ret = get_wait_info(n_descs, descs, n_waits, last_wait);
+        if (ret) {
+                gds_err("error %d in get_wait_info\n", ret);
+                goto out;
+        }
+
+        gds_dbg("n_descs=%zu n_waits=%zu n_mem_ops=%zu\n", n_descs, n_waits, n_mem_ops);
+
+        // move flush to last wait in the whole batch
+        if (n_waits && no_network_descs_after_entry(n_descs, descs, last_wait)) {
+                gds_dbg("optimizing FLUSH to last wait i=%zu\n", last_wait);
+                move_flush = true;
+        }
+        // alternatively, remove flush for wait is next op is a wait too
+
+        peer = peer_from_stream(stream);
+        if (!peer) {
+                return EINVAL;
+        }
+
+        for (i = 0; i < n_descs; ++i) {
+                gds_descriptor_t *desc = descs + i;
+                switch (desc->tag) {
+                        case GDS_TAG_SEND: {
+                                gds_send_request_s *sreq = to_gds_send_request_s(desc->send);
+                                retcode = gds_post_ops(peer, sreq->commit.entries, sreq->commit.storage, params);
+                                if (retcode) {
+                                        gds_err("error %d in gds_post_ops\n", retcode);
+                                        ret = retcode;
+                                        goto out;
+                                }
+                                break;
+                        }
+                        case GDS_TAG_WAIT: {
+                                gds_wait_request_s *wreq = to_gds_wait_request_s(desc->wait);
+                                int flags = 0;
+                                if (move_flush && i != last_wait) {
+                                        gds_dbg("discarding FLUSH!\n");
+                                        flags = GDS_POST_OPS_DISCARD_WAIT_FLUSH;
+                                }
+                                retcode = gds_post_ops(peer, wreq->peek.entries, wreq->peek.storage, params, flags);
+                                if (retcode) {
+                                        gds_err("error %d in gds_post_ops\n", retcode);
+                                        ret = retcode;
+                                        goto out;
+                                }
+                                break;
+                        }
+                        case GDS_TAG_WAIT_VALUE32:
+                                retcode = gds_fill_poll(peer, params, desc->wait32.ptr, desc->wait32.value, desc->wait32.cond_flags, desc->wait32.flags);
+                                if (retcode) {
+                                        gds_err("error %d in gds_fill_poll\n", retcode);
+                                        ret = retcode;
+                                        goto out;
+                                }
+                                break;
+                        case GDS_TAG_WRITE_VALUE32:
+                                retcode = gds_fill_poke(peer, params, desc->write32.ptr, desc->write32.value, desc->write32.flags);
+                                if (retcode) {
+                                        gds_err("error %d in gds_fill_poke\n", retcode);
+                                        ret = retcode;
+                                        goto out;
+                                }
+                                break;
+                        case GDS_TAG_WRITE_MEMORY:
+                                retcode = gds_fill_inlcpy(peer, params, desc->writemem.dest, desc->writemem.src, desc->writemem.count, desc->writemem.flags);
+                                if (retcode) {
+                                        gds_err("error %d in gds_fill_inlcpy\n", retcode);
+                                        ret = retcode;
+                                        goto out;
+                                }
+                                break;
+                        default:
+                                gds_err("invalid tag for %zu entry\n", i);
+                                ret = EINVAL;
+                                goto out;
+                                break;
+                }
+        }
+        retcode = gds_stream_batch_ops(peer, stream, params, 0);
+        if (retcode) {
+                gds_err("error %d in gds_stream_batch_ops\n", retcode);
+                ret = retcode;
+                goto out;
+        }
 
 out:
-    for(i = 0; i < n_descs; ++i) {
-        gds_descriptor_t *desc = descs + i;
-        if (desc->tag == GDS_TAG_SEND) {
-            if (!(to_gds_send_request_s(desc->send)->flags & GDS_FLAG_INTERNAL_KEEP_REQUESTS)) {
-                free(desc->send->handle);
-                desc->send->handle = NULL;
-            }
+        for(i = 0; i < n_descs; ++i) {
+                gds_descriptor_t *desc = descs + i;
+                if (desc->tag == GDS_TAG_SEND) {
+                        if (!(to_gds_send_request_s(desc->send)->flags & GDS_FLAG_INTERNAL_KEEP_REQUESTS)) {
+                                free(desc->send->handle);
+                                desc->send->handle = NULL;
+                        }
+                }
+                else if (desc->tag == GDS_TAG_WAIT) {
+                        if (!(to_gds_wait_request_s(desc->wait)->flags & GDS_FLAG_INTERNAL_KEEP_REQUESTS)) {
+                                free(desc->wait->handle);
+                                desc->wait->handle = NULL;
+                        }
+                }
         }
-        else if (desc->tag == GDS_TAG_WAIT) {
-            if (!(to_gds_wait_request_s(desc->wait)->flags & GDS_FLAG_INTERNAL_KEEP_REQUESTS)) {
-                free(desc->wait->handle);
-                desc->wait->handle = NULL;
-            }
-        }
-    }
-    return ret;
+        return ret;
 }
 
 //-----------------------------------------------------------------------------
 
 int gds_post_descriptors(size_t n_descs, gds_descriptor_t *descs, int flags)
 {
-    size_t i;
-    int ret = 0;
-    int retcode = 0;
-    for(i = 0; i < n_descs; ++i) {
-        gds_descriptor_t *desc = descs + i;
-        switch(desc->tag) {
-            case GDS_TAG_SEND: {
-                gds_dbg("desc[%zu] SEND\n", i);
-                gds_send_request_s *sreq = to_gds_send_request_s(desc->send);
-                retcode = gds_post_ops_on_cpu(sreq->commit.entries, sreq->commit.storage, flags);
-                if (retcode) {
-                    gds_err("error %d in gds_post_ops_on_cpu\n", retcode);
-                    ret = retcode;
-                    goto out;
-                }
-                break;
-            }
-            case GDS_TAG_WAIT: {
-                gds_dbg("desc[%zu] WAIT\n", i);
-                gds_wait_request_s *wreq = to_gds_wait_request_s(desc->wait);
-                retcode = gds_post_ops_on_cpu(wreq->peek.entries, wreq->peek.storage, flags);
-                if (retcode) {
-                    gds_err("error %d in gds_post_ops_on_cpu\n", retcode);
-                    ret = retcode;
-                    goto out;
-                }
-                break;
-            }
-            case GDS_TAG_WAIT_VALUE32: {
-                gds_dbg("desc[%zu] WAIT_VALUE32\n", i);
-                uint32_t *ptr = desc->wait32.ptr;
-                uint32_t value = desc->wait32.value;
-                bool flush = false;
-                if (desc->wait32.flags & GDS_WAIT_POST_FLUSH_REMOTE) {
-                    gds_err("GDS_WAIT_POST_FLUSH_REMOTE flag is not supported yet\n");
-                    flush = true;
-                }
-                gds_memory_type_t mem_type = (gds_memory_type_t)(desc->wait32.flags & GDS_MEMORY_MASK);
-                switch(mem_type) {
-                    case GDS_MEMORY_GPU:
-                        // dereferencing ptr may fail if ptr points to CUDA device memory
-                    case GDS_MEMORY_HOST:
-                    case GDS_MEMORY_IO:
-                        break;
-                    default:
-                        gds_err("invalid memory type 0x%02x in WAIT_VALUE32\n", mem_type);
-                        ret = EINVAL;
-                        goto out;
-                        break;
-                }
-                bool done = false;
-                do {
-                    uint32_t data = gds_atomic_get(ptr);
-                    switch(desc->wait32.cond_flags) {
-                        case GDS_WAIT_COND_GEQ:
-                            done = ((int32_t)data - (int32_t)value >= 0);
-                            break;
-                        case GDS_WAIT_COND_EQ:
-                            done = (data == value);
-                            break;
-                        case GDS_WAIT_COND_AND:
-                            done = (data & value);
-                            break;
-                        case GDS_WAIT_COND_NOR:
-                            done = ~(data | value);
-                            break;
+        size_t i;
+        int ret = 0;
+        int retcode = 0;
+        for(i = 0; i < n_descs; ++i) {
+                gds_descriptor_t *desc = descs + i;
+                switch(desc->tag) {
+                        case GDS_TAG_SEND: {
+                                gds_dbg("desc[%zu] SEND\n", i);
+                                gds_send_request_s *sreq = to_gds_send_request_s(desc->send);
+                                retcode = gds_post_ops_on_cpu(sreq->commit.entries, sreq->commit.storage, flags);
+                                if (retcode) {
+                                        gds_err("error %d in gds_post_ops_on_cpu\n", retcode);
+                                        ret = retcode;
+                                        goto out;
+                                }
+                                break;
+                        }
+                        case GDS_TAG_WAIT: {
+                                gds_dbg("desc[%zu] WAIT\n", i);
+                                gds_wait_request_s *wreq = to_gds_wait_request_s(desc->wait);
+                                retcode = gds_post_ops_on_cpu(wreq->peek.entries, wreq->peek.storage, flags);
+                                if (retcode) {
+                                        gds_err("error %d in gds_post_ops_on_cpu\n", retcode);
+                                        ret = retcode;
+                                        goto out;
+                                }
+                                break;
+                        }
+                        case GDS_TAG_WAIT_VALUE32: {
+                                gds_dbg("desc[%zu] WAIT_VALUE32\n", i);
+                                uint32_t *ptr = desc->wait32.ptr;
+                                uint32_t value = desc->wait32.value;
+                                bool flush = false;
+                                if (desc->wait32.flags & GDS_WAIT_POST_FLUSH_REMOTE) {
+                                        gds_err("GDS_WAIT_POST_FLUSH_REMOTE flag is not supported yet\n");
+                                        flush = true;
+                                }
+                                gds_memory_type_t mem_type = (gds_memory_type_t)(desc->wait32.flags & GDS_MEMORY_MASK);
+                                switch (mem_type) {
+                                        case GDS_MEMORY_GPU:
+                                                // dereferencing ptr may fail if ptr points to CUDA device memory
+                                        case GDS_MEMORY_HOST:
+                                        case GDS_MEMORY_IO:
+                                                break;
+                                        default:
+                                                gds_err("invalid memory type 0x%02x in WAIT_VALUE32\n", mem_type);
+                                                ret = EINVAL;
+                                                goto out;
+                                                break;
+                                }
+                                bool done = false;
+                                do {
+                                        uint32_t data = gds_atomic_get(ptr);
+                                        switch (desc->wait32.cond_flags) {
+                                                case GDS_WAIT_COND_GEQ:
+                                                        done = ((int32_t)data - (int32_t)value >= 0);
+                                                        break;
+                                                case GDS_WAIT_COND_EQ:
+                                                        done = (data == value);
+                                                        break;
+                                                case GDS_WAIT_COND_AND:
+                                                        done = (data & value);
+                                                        break;
+                                                case GDS_WAIT_COND_NOR:
+                                                        done = ~(data | value);
+                                                        break;
+                                                default:
+                                                        gds_err("invalid condition flags 0x%02x in WAIT_VALUE32\n", desc->wait32.cond_flags);
+                                                        goto out;
+                                                        break;
+                                        }
+                                        if (done)
+                                                break;
+                                        // TODO: more aggressive CPU relaxing needed here to avoid starving I/O fabric
+                                        arch_cpu_relax();
+                                } while(true);
+                                break;
+                        }
+                        case GDS_TAG_WRITE_VALUE32: {
+                                gds_dbg("desc[%zu] WRITE_VALUE32\n", i);
+                                uint32_t *ptr = desc->write32.ptr;
+                                uint32_t value = desc->write32.value;
+                                gds_memory_type_t mem_type = (gds_memory_type_t)(desc->write32.flags & GDS_MEMORY_MASK);
+                                switch(mem_type) {
+                                        case GDS_MEMORY_GPU:
+                                                // dereferencing ptr may fail if ptr points to CUDA device memory
+                                        case GDS_MEMORY_HOST:
+                                        case GDS_MEMORY_IO:
+                                                break;
+                                        default:
+                                                gds_err("invalid memory type 0x%02x in WRITE_VALUE32\n", mem_type);
+                                                ret = EINVAL;
+                                                goto out;
+                                                break;
+                                }
+                                bool barrier = (desc->write32.flags & GDS_WRITE_PRE_BARRIER_SYS);
+                                if (barrier)
+                                        wmb();
+                                gds_atomic_set(ptr, value);
+                                break;
+                        }
+                        case GDS_TAG_WRITE_MEMORY: {
+                                void *dest = desc->writemem.dest;
+                                const void *src = desc->writemem.src;
+                                size_t nbytes = desc->writemem.count;
+                                bool barrier = (desc->writemem.flags & GDS_WRITE_MEMORY_POST_BARRIER_SYS);
+                                gds_memory_type_t mem_type = memtype_from_flags(desc->writemem.flags);
+                                gds_dbg("desc[%zu] WRITE_MEMORY dest=%p src=%p len=%zu memtype=%02x\n", i, dest, src, nbytes, mem_type);
+                                switch(mem_type) {
+                                        case GDS_MEMORY_GPU:
+                                        case GDS_MEMORY_HOST:
+                                                memcpy(dest, src, nbytes);
+                                                break;
+                                        case GDS_MEMORY_IO:
+                                                assert(nbytes % sizeof(uint64_t));
+                                                assert(((unsigned long)dest & 0x7) == 0);
+                                                gds_bf_copy((uint64_t*)dest, (uint64_t*)src, nbytes);
+                                                break;
+                                        default:
+                                                assert(!"invalid mem type");
+                                                break;
+                                }
+                                if (barrier)
+                                        wmb();
+                                break;
+                        }
                         default:
-                            gds_err("invalid condition flags 0x%02x in WAIT_VALUE32\n", desc->wait32.cond_flags);
-                            goto out;
-                            break;
-                    }
-                    if (done)
-                        break;
-                    // TODO: more aggressive CPU relaxing needed here to avoid starving I/O fabric
-                    arch_cpu_relax();
-                } while(true);
-                break;
-            }
-            case GDS_TAG_WRITE_VALUE32: {
-                gds_dbg("desc[%zu] WRITE_VALUE32\n", i);
-                uint32_t *ptr = desc->write32.ptr;
-                uint32_t value = desc->write32.value;
-                gds_memory_type_t mem_type = (gds_memory_type_t)(desc->write32.flags & GDS_MEMORY_MASK);
-                switch(mem_type) {
-                    case GDS_MEMORY_GPU:
-                        // dereferencing ptr may fail if ptr points to CUDA device memory
-                    case GDS_MEMORY_HOST:
-                    case GDS_MEMORY_IO:
-                        break;
-                    default:
-                        gds_err("invalid memory type 0x%02x in WRITE_VALUE32\n", mem_type);
-                        ret = EINVAL;
-                        goto out;
-                        break;
+                                gds_err("invalid tag for %zu entry\n", i);
+                                ret = EINVAL;
+                                goto out;
+                                break;
                 }
-                bool barrier = (desc->write32.flags & GDS_WRITE_PRE_BARRIER_SYS);
-                if (barrier)
-                    wmb();
-                gds_atomic_set(ptr, value);
-                break;
-            }
-            case GDS_TAG_WRITE_MEMORY: {
-                void *dest = desc->writemem.dest;
-                const void *src = desc->writemem.src;
-                size_t nbytes = desc->writemem.count;
-                bool barrier = (desc->writemem.flags & GDS_WRITE_MEMORY_POST_BARRIER_SYS);
-                gds_memory_type_t mem_type = memtype_from_flags(desc->writemem.flags);
-                gds_dbg("desc[%zu] WRITE_MEMORY dest=%p src=%p len=%zu memtype=%02x\n", i, dest, src, nbytes, mem_type);
-                switch(mem_type) {
-                    case GDS_MEMORY_GPU:
-                    case GDS_MEMORY_HOST:
-                        memcpy(dest, src, nbytes);
-                        break;
-                    case GDS_MEMORY_IO:
-                        assert(nbytes % sizeof(uint64_t));
-                        assert(((unsigned long)dest & 0x7) == 0);
-                        gds_bf_copy((uint64_t*)dest, (uint64_t*)src, nbytes);
-                        break;
-                    default:
-                        assert(!"invalid mem type");
-                        break;
-                }
-                if (barrier)
-                    wmb();
-                break;
-            }
-            default:
-                gds_err("invalid tag for %zu entry\n", i);
-                ret = EINVAL;
-                goto out;
-                break;
         }
-    }
 out:
-    for(i = 0; i < n_descs; ++i) {
-        gds_descriptor_t *desc = descs + i;
-        if (desc->tag == GDS_TAG_SEND) {
-            if (!(to_gds_send_request_s(desc->send)->flags & GDS_FLAG_INTERNAL_KEEP_REQUESTS)) {
-                free(desc->send->handle);
-                desc->send->handle = NULL;
-            }
+        for(i = 0; i < n_descs; ++i) {
+                gds_descriptor_t *desc = descs + i;
+                if (desc->tag == GDS_TAG_SEND) {
+                        if (!(to_gds_send_request_s(desc->send)->flags & GDS_FLAG_INTERNAL_KEEP_REQUESTS)) {
+                                free(desc->send->handle);
+                                desc->send->handle = NULL;
+                        }
+                }
+                else if (desc->tag == GDS_TAG_WAIT) {
+                        if (!(to_gds_wait_request_s(desc->wait)->flags & GDS_FLAG_INTERNAL_KEEP_REQUESTS)) {
+                                free(desc->wait->handle);
+                                desc->wait->handle = NULL;
+                        }
+                }
         }
-        else if (desc->tag == GDS_TAG_WAIT) {
-            if (!(to_gds_wait_request_s(desc->wait)->flags & GDS_FLAG_INTERNAL_KEEP_REQUESTS)) {
-                free(desc->wait->handle);
-                desc->wait->handle = NULL;
-            }
-        }
-    }
-    return ret;
+        return ret;
 }
 
 //-----------------------------------------------------------------------------
 
 /*
  * Local variables:
- *  c-indent-level: 4
- *  c-basic-offset: 4
- *  tab-width: 4
+ *  c-indent-level: 8
+ *  c-basic-offset: 8
+ *  tab-width: 8
  *  indent-tabs-mode: nil
  * End:
  */

--- a/src/apis.cpp
+++ b/src/apis.cpp
@@ -825,6 +825,52 @@ out:
 
 //-----------------------------------------------------------------------------
 
+int gds_alloc_send_request(gds_send_request_t **request, int num)
+{
+    if (num < 0)
+        return -EINVAL;
+
+    *request = (gds_send_request_t *)calloc(num, sizeof(gds_send_request_t));
+
+    if (*request == NULL && num != 0)
+        return -ENOMEM;
+
+    return 0;
+}
+
+//-----------------------------------------------------------------------------
+
+void gds_free_send_request(gds_send_request_t *request)
+{
+    if (request)
+        free(request);
+}
+
+//-----------------------------------------------------------------------------
+
+int gds_alloc_wait_request(gds_wait_request_t **request, int num)
+{
+    if (num < 0)
+        return -EINVAL;
+
+    *request = (gds_wait_request_t *)calloc(num, sizeof(gds_wait_request_t));
+
+    if (*request == NULL && num != 0)
+        return -ENOMEM;
+
+    return 0;
+}
+
+//-----------------------------------------------------------------------------
+
+void gds_free_wait_request(gds_wait_request_t *request)
+{
+    if (request)
+        free(request);
+}
+
+//-----------------------------------------------------------------------------
+
 /*
  * Local variables:
  *  c-indent-level: 8

--- a/src/apis.cpp
+++ b/src/apis.cpp
@@ -89,7 +89,7 @@ static void gds_init_wait_request(gds_wait_request_s *request, uint32_t offset)
 
 //-----------------------------------------------------------------------------
 
-static int gds_rollback_qp(struct gds_qp *qp, gds_send_request_s * send_info, enum ibv_exp_rollback_flags flag)
+static int gds_rollback_qp(gds_qp_t *qp, gds_send_request_s *send_info, enum ibv_exp_rollback_flags flag)
 {
         struct ibv_exp_rollback_ctx rollback;
         int ret=0;
@@ -124,7 +124,7 @@ out:
 
 //-----------------------------------------------------------------------------
 
-static int gds_prepare_send_internal(struct gds_qp *qp, gds_send_wr *p_ewr, 
+static int gds_prepare_send_internal(gds_qp_t *qp, gds_send_wr *p_ewr, 
                                         gds_send_wr **bad_ewr, 
                                         gds_send_request_s *request)
 {
@@ -152,7 +152,7 @@ out:
 
 //-----------------------------------------------------------------------------
 
-static int gds_prepare_wait_cq_internal(struct gds_cq *cq, gds_wait_request_s *request, int flags)
+static int gds_prepare_wait_cq_internal(gds_cq_t *cq, gds_wait_request_s *request, int flags)
 {
     int retcode = 0;
     if (flags != 0) {
@@ -178,7 +178,7 @@ out:
 
 //-----------------------------------------------------------------------------
 
-int gds_post_send(struct gds_qp *qp, gds_send_wr *p_ewr, gds_send_wr **bad_ewr)
+int gds_post_send(gds_qp_t *qp, gds_send_wr *p_ewr, gds_send_wr **bad_ewr)
 {
         int ret = 0, ret_roll=0;
         gds_send_request_s send_info;
@@ -205,7 +205,7 @@ out:
 
 //-----------------------------------------------------------------------------
 
-int gds_post_recv(struct gds_qp *qp, struct ibv_recv_wr *wr, struct ibv_recv_wr **bad_wr)
+int gds_post_recv(gds_qp_t *qp, struct ibv_recv_wr *wr, struct ibv_recv_wr **bad_wr)
 {
         int ret = 0;
 
@@ -224,7 +224,7 @@ out:
 
 //-----------------------------------------------------------------------------
 
-int gds_prepare_send(struct gds_qp *qp, gds_send_wr *p_ewr, 
+int gds_prepare_send(gds_qp_t *qp, gds_send_wr *p_ewr, 
                      gds_send_wr **bad_ewr, 
                      gds_send_request_t *request)
 {
@@ -252,7 +252,7 @@ int gds_prepare_send(struct gds_qp *qp, gds_send_wr *p_ewr,
 
 //-----------------------------------------------------------------------------
 
-int gds_stream_queue_send(CUstream stream, struct gds_qp *qp, gds_send_wr *p_ewr, gds_send_wr **bad_ewr)
+int gds_stream_queue_send(CUstream stream, gds_qp_t *qp, gds_send_wr *p_ewr, gds_send_wr **bad_ewr)
 {
     int ret = 0, ret_roll = 0;
     gds_send_request_s send_info;
@@ -332,7 +332,7 @@ out:
 
 //-----------------------------------------------------------------------------
 
-int gds_prepare_wait_cq(struct gds_cq *cq, gds_wait_request_t *request, int flags)
+int gds_prepare_wait_cq(gds_cq_t *cq, gds_wait_request_t *request, int flags)
 {
     int ret = 0;
     gds_wait_request_s *wait_request = (gds_wait_request_s *)malloc(sizeof(gds_wait_request_s));
@@ -415,7 +415,7 @@ int gds_stream_post_wait_cq_all(CUstream stream, int count, gds_wait_request_t *
 
 //-----------------------------------------------------------------------------
 
-static int gds_abort_wait_cq(struct gds_cq *cq, gds_wait_request_s *request)
+static int gds_abort_wait_cq(gds_cq_t *cq, gds_wait_request_s *request)
 {
     assert(cq);
     assert(request);
@@ -427,7 +427,7 @@ static int gds_abort_wait_cq(struct gds_cq *cq, gds_wait_request_s *request)
 
 //-----------------------------------------------------------------------------
 
-int gds_stream_wait_cq(CUstream stream, struct gds_cq *cq, int flags)
+int gds_stream_wait_cq(CUstream stream, gds_cq_t *cq, int flags)
 {
     int retcode = 0;
     int ret;
@@ -464,7 +464,7 @@ out:
 
 //-----------------------------------------------------------------------------
 
-int gds_post_wait_cq(struct gds_cq *cq, gds_wait_request_t *request, int flags)
+int gds_post_wait_cq(gds_cq_t *cq, gds_wait_request_t *request, int flags)
 {
     int retcode = 0;
     gds_wait_request_s *wait_request = to_gds_wait_request_s(request);

--- a/src/archutils.h
+++ b/src/archutils.h
@@ -25,12 +25,12 @@ static void arch_cpu_relax(void)
 static void wmb(void) __attribute__((unused)) ;
 static void wmb(void) 
 {
-	asm volatile("sync") ; 
+        asm volatile("sync") ; 
 }
 static void rmb(void) __attribute__((unused)) ;
 static void rmb(void) 
 {
-	asm volatile("sync") ; 
+        asm volatile("sync") ; 
 }
 
 #else

--- a/src/gdsync.cpp
+++ b/src/gdsync.cpp
@@ -1948,17 +1948,6 @@ gds_qp_t *gds_create_qp(struct ibv_pd *pd, struct ibv_context *context,
         gqp->recv_cq.cq = qp->recv_cq;
         gqp->recv_cq.curr_offset = 0;
 
-        // The contents of some fields in exp_qp_attr are modified during the process.
-        // We copy them to qp_attr in order to expose back to the user.
-        memcpy(qp_attr, &exp_qp_attr, sizeof(gds_qp_init_attr_t));
-        qp_attr->qp_context = exp_qp_attr.qp_context;
-        qp_attr->send_cq = exp_qp_attr.send_cq;
-        qp_attr->recv_cq = exp_qp_attr.recv_cq;
-        qp_attr->srq = exp_qp_attr.srq;
-        memcpy(&qp_attr->cap, &exp_qp_attr.cap, sizeof(struct ibv_qp_cap));
-        qp_attr->qp_type = exp_qp_attr.qp_type;
-        qp_attr->sq_sig_all = exp_qp_attr.sq_sig_all;
-
         gds_dbg("created gds_qp=%p\n", gqp);
 
         return gqp;

--- a/src/gdsync.cpp
+++ b/src/gdsync.cpp
@@ -1738,13 +1738,13 @@ static ibv_exp_res_domain *gds_create_res_domain(struct ibv_context *context)
 
 //-----------------------------------------------------------------------------
 
-static struct gds_cq *
+static gds_cq_t *
 gds_create_cq_internal(struct ibv_context *context, int cqe,
                         void *cq_context, struct ibv_comp_channel *channel,
                         int comp_vector, int gpu_id, gds_alloc_cq_flags_t flags,
                         struct ibv_exp_res_domain * res_domain)
 {
-        struct gds_cq *gcq = NULL;
+        gds_cq_t *gcq = NULL;
         ibv_exp_cq_init_attr attr;
         gds_peer *peer = NULL;
         gds_peer_attr *peer_attr = NULL;
@@ -1756,7 +1756,7 @@ gds_create_cq_internal(struct ibv_context *context, int cqe,
             return NULL;
         }
 
-        gcq = (struct gds_cq*)calloc(1, sizeof(struct gds_cq));
+        gcq = (gds_cq_t*)calloc(1, sizeof(gds_cq_t));
         if (!gcq) {
             gds_err("cannot allocate memory\n");
             return NULL;
@@ -1795,13 +1795,13 @@ gds_create_cq_internal(struct ibv_context *context, int cqe,
 }
 
 //Note: general create cq function, not really used for now!
-struct gds_cq *
+gds_cq_t *
 gds_create_cq(struct ibv_context *context, int cqe,
               void *cq_context, struct ibv_comp_channel *channel,
               int comp_vector, int gpu_id, gds_alloc_cq_flags_t flags)
 {
         int ret = 0;
-        struct gds_cq *gcq = NULL;
+        gds_cq_t *gcq = NULL;
         //TODO: leak of res_domain
         struct ibv_exp_res_domain * res_domain;
         gds_dbg("cqe=%d gpu_id=%d cq_flags=%08x\n", cqe, gpu_id, flags);
@@ -1838,15 +1838,15 @@ gds_create_cq(struct ibv_context *context, int cqe,
 
 //-----------------------------------------------------------------------------
 
-struct gds_qp *gds_create_qp(struct ibv_pd *pd, struct ibv_context *context,
-                                gds_qp_init_attr_t *qp_attr, int gpu_id, int flags)
+gds_qp_t *gds_create_qp(struct ibv_pd *pd, struct ibv_context *context,
+                        gds_qp_init_attr_t *qp_attr, int gpu_id, int flags)
 {
         int ret = 0;
         gds_qp_internal_t *gqpi = NULL;
-        struct gds_qp *gqp = NULL;
+        gds_qp_t *gqp = NULL;
         struct ibv_qp *qp = NULL;
         struct ibv_exp_qp_init_attr exp_qp_attr;
-        struct gds_cq *rx_gcq = NULL, *tx_gcq = NULL;
+        gds_cq_t *rx_gcq = NULL, *tx_gcq = NULL;
         gds_peer *peer = NULL;
         gds_peer_attr *peer_attr = NULL;
         int old_errno = errno;
@@ -1953,7 +1953,7 @@ err:
 
 //-----------------------------------------------------------------------------
 
-int gds_destroy_qp(struct gds_qp *gqp)
+int gds_destroy_qp(gds_qp_t *gqp)
 {
         int retcode = 0;
         int ret;

--- a/src/gdsync.cpp
+++ b/src/gdsync.cpp
@@ -1861,8 +1861,18 @@ gds_qp_t *gds_create_qp(struct ibv_pd *pd, struct ibv_context *context,
                 return NULL;
         }
 
+        // We need to create qp with exp-verbs since we need to enable peer ops.
+        // However, users provide us ib-verbs qp-init-attr.
+        // So, we copy field-by-field to exp-qp-init-attr.
+        // As MLNX OFED's ibv_qp_init_attr is not fully compatible with ibv_exp_qp_init_attr, field-by-field copy is preferred over memcpy.
         memset(&exp_qp_attr, 0, sizeof(struct ibv_exp_qp_init_attr));
-        memcpy(&exp_qp_attr, qp_attr, sizeof(gds_qp_init_attr_t));
+        exp_qp_attr.qp_context = qp_attr->qp_context;
+        exp_qp_attr.send_cq = qp_attr->send_cq;
+        exp_qp_attr.recv_cq = qp_attr->recv_cq;
+        exp_qp_attr.srq = qp_attr->srq;
+        memcpy(&exp_qp_attr.cap, &qp_attr->cap, sizeof(struct ibv_qp_cap));
+        exp_qp_attr.qp_type = qp_attr->qp_type;
+        exp_qp_attr.sq_sig_all = qp_attr->sq_sig_all;
 
         gqpi = (gds_qp_internal_t *)calloc(1, sizeof(gds_qp_internal_t));
         if (!gqpi) {
@@ -1938,7 +1948,16 @@ gds_qp_t *gds_create_qp(struct ibv_pd *pd, struct ibv_context *context,
         gqp->recv_cq.cq = qp->recv_cq;
         gqp->recv_cq.curr_offset = 0;
 
+        // The contents of some fields in exp_qp_attr are modified during the process.
+        // We copy them to qp_attr in order to expose back to the user.
         memcpy(qp_attr, &exp_qp_attr, sizeof(gds_qp_init_attr_t));
+        qp_attr->qp_context = exp_qp_attr.qp_context;
+        qp_attr->send_cq = exp_qp_attr.send_cq;
+        qp_attr->recv_cq = exp_qp_attr.recv_cq;
+        qp_attr->srq = exp_qp_attr.srq;
+        memcpy(&qp_attr->cap, &exp_qp_attr.cap, sizeof(struct ibv_qp_cap));
+        qp_attr->qp_type = exp_qp_attr.qp_type;
+        qp_attr->sq_sig_all = exp_qp_attr.sq_sig_all;
 
         gds_dbg("created gds_qp=%p\n", gqp);
 

--- a/src/gdsync.cpp
+++ b/src/gdsync.cpp
@@ -72,18 +72,18 @@ int gds_dbg_enabled()
 #if 0
 int gds_flusher_enabled()
 {
-    static int gds_flusher_is_enabled = -1;
-    if (-1 == gds_flusher_is_enabled) {
-        const char *env = getenv("GDS_ENABLE_FLUSHER");
-        if (env) {
-            int en = atoi(env);
-            gds_flusher_is_enabled = !!en;
-        } else
-            gds_flusher_is_enabled = 0;
-    
-        gds_warn("GDS_ENABLE_FLUSHER=%d\n", gds_flusher_is_enabled);
-    }
-    return gds_flusher_is_enabled;
+        static int gds_flusher_is_enabled = -1;
+        if (-1 == gds_flusher_is_enabled) {
+                const char *env = getenv("GDS_ENABLE_FLUSHER");
+                if (env) {
+                        int en = atoi(env);
+                        gds_flusher_is_enabled = !!en;
+                } else
+                        gds_flusher_is_enabled = 0;
+
+                gds_warn("GDS_ENABLE_FLUSHER=%d\n", gds_flusher_is_enabled);
+        }
+        return gds_flusher_is_enabled;
 }
 #endif
 
@@ -220,7 +220,7 @@ static bool gds_enable_weak_consistency()
                 gds_dbg("GDS_DISABLE_WEAK_CONSISTENCY=%d\n", gds_disable_weak_consistency);
         }
         gds_dbg("gds_disable_weak_consistency=%d\n",
-                gds_disable_weak_consistency);
+                        gds_disable_weak_consistency);
         return !gds_disable_weak_consistency;
 }
 
@@ -230,12 +230,12 @@ static bool gds_enable_dump_memops()
 {
         static int gds_enable_dump_memops = -1;
         if (-1 == gds_enable_dump_memops) {
-            const char *env = getenv("GDS_ENABLE_DUMP_MEMOPS");
-            if (env)
-                    gds_enable_dump_memops = !!atoi(env);
-            else
-                    gds_enable_dump_memops = 0; // disabled by default
-            gds_dbg("GDS_ENABLE_DUMP_MEMOPS=%d\n", gds_enable_dump_memops);
+                const char *env = getenv("GDS_ENABLE_DUMP_MEMOPS");
+                if (env)
+                        gds_enable_dump_memops = !!atoi(env);
+                else
+                        gds_enable_dump_memops = 0; // disabled by default
+                gds_dbg("GDS_ENABLE_DUMP_MEMOPS=%d\n", gds_enable_dump_memops);
         }
         return gds_enable_dump_memops;
 }
@@ -245,48 +245,48 @@ static bool gds_enable_dump_memops()
 void gds_dump_param(CUstreamBatchMemOpParams *param)
 {
         switch(param->operation) {
-        case CU_STREAM_MEM_OP_WAIT_VALUE_32:
-                gds_info("WAIT32 addr:%p alias:%p value:%08x flags:%08x\n",
-                        (void*)param->waitValue.address,
-                        (void*)param->writeValue.alias,
-                        param->waitValue.value,
-                        param->waitValue.flags);
-                break;
+                case CU_STREAM_MEM_OP_WAIT_VALUE_32:
+                        gds_info("WAIT32 addr:%p alias:%p value:%08x flags:%08x\n",
+                                        (void*)param->waitValue.address,
+                                        (void*)param->writeValue.alias,
+                                        param->waitValue.value,
+                                        param->waitValue.flags);
+                        break;
 
-        case CU_STREAM_MEM_OP_WRITE_VALUE_32:
-                gds_info("WRITE32 addr:%p alias:%p value:%08x flags:%08x\n",
-                        (void*)param->writeValue.address,
-                        (void*)param->writeValue.alias,
-                        param->writeValue.value,
-                        param->writeValue.flags);
-                break;
+                case CU_STREAM_MEM_OP_WRITE_VALUE_32:
+                        gds_info("WRITE32 addr:%p alias:%p value:%08x flags:%08x\n",
+                                        (void*)param->writeValue.address,
+                                        (void*)param->writeValue.alias,
+                                        param->writeValue.value,
+                                        param->writeValue.flags);
+                        break;
 
-        case CU_STREAM_MEM_OP_FLUSH_REMOTE_WRITES:
-                gds_dbg("FLUSH\n");
-                break;
+                case CU_STREAM_MEM_OP_FLUSH_REMOTE_WRITES:
+                        gds_dbg("FLUSH\n");
+                        break;
 
 #if HAVE_DECL_CU_STREAM_MEM_OP_WRITE_MEMORY
-        case CU_STREAM_MEM_OP_WRITE_MEMORY:
-                gds_info("INLINECOPY addr:%p alias:%p src:%p len=%zu flags:%08x\n",
-                        (void*)param->writeMemory.address,
-                        (void*)param->writeMemory.alias,
-                        (void*)param->writeMemory.src,
-                        param->writeMemory.byteCount,
-                        param->writeMemory.flags);
-                break;
+                case CU_STREAM_MEM_OP_WRITE_MEMORY:
+                        gds_info("INLINECOPY addr:%p alias:%p src:%p len=%zu flags:%08x\n",
+                                        (void*)param->writeMemory.address,
+                                        (void*)param->writeMemory.alias,
+                                        (void*)param->writeMemory.src,
+                                        param->writeMemory.byteCount,
+                                        param->writeMemory.flags);
+                        break;
 #endif
 
 #if HAVE_DECL_CU_STREAM_MEM_OP_MEMORY_BARRIER
-        case CU_STREAM_MEM_OP_MEMORY_BARRIER:
-                gds_info("MEMORY_BARRIER scope:%02x set_before=%02x set_after=%02x\n",
-                         param->memoryBarrier.scope,
-                         param->memoryBarrier.set_before,
-                         param->memoryBarrier.set_after);
-                break;
+                case CU_STREAM_MEM_OP_MEMORY_BARRIER:
+                        gds_info("MEMORY_BARRIER scope:%02x set_before=%02x set_after=%02x\n",
+                                        param->memoryBarrier.scope,
+                                        param->memoryBarrier.set_before,
+                                        param->memoryBarrier.set_after);
+                        break;
 #endif
-        default:
-                gds_err("unsupported operation=%d\n", param->operation);
-                break;
+                default:
+                        gds_err("unsupported operation=%d\n", param->operation);
+                        break;
         }
 }
 
@@ -313,8 +313,8 @@ int gds_fill_membar(gds_peer *peer, gds_op_list_t &ops, int flags)
                 param.operation = CU_STREAM_MEM_OP_FLUSH_REMOTE_WRITES;
                 param.flushRemoteWrites.flags = 0;
                 gds_dbg("op=%d flush_remote flags=%08x\n",
-                        param.operation,
-                        param.flushRemoteWrites.flags);
+                                param.operation,
+                                param.flushRemoteWrites.flags);
         } else {
                 param.operation = CU_STREAM_MEM_OP_MEMORY_BARRIER;
                 if (flags & GDS_MEMBAR_MLX5) {
@@ -333,10 +333,10 @@ int gds_fill_membar(gds_peer *peer, gds_op_list_t &ops, int flags)
                         goto out;
                 }
                 gds_dbg("op=%d membar scope:%02x set_before=%02x set_after=%02x\n",
-                        param.operation,
-                        param.memoryBarrier.scope,
-                        param.memoryBarrier.set_before,
-                        param.memoryBarrier.set_after);
+                                param.operation,
+                                param.memoryBarrier.scope,
+                                param.memoryBarrier.set_before,
+                                param.memoryBarrier.set_after);
 
         }
         ops.push_back(param);
@@ -381,11 +381,11 @@ static int gds_fill_inlcpy(gds_peer *peer, gds_op_list_t &ops, CUdeviceptr addr,
         else
                 param.writeMemory.flags = CU_STREAM_WRITE_MEMORY_NO_MEMORY_BARRIER;
         gds_dbg("op=%d addr=%p src=%p size=%zd flags=%08x\n",
-                param.operation,
-                (void*)param.writeMemory.address,
-                param.writeMemory.src,
-                param.writeMemory.byteCount,
-                param.writeMemory.flags);
+                        param.operation,
+                        (void*)param.writeMemory.address,
+                        param.writeMemory.src,
+                        param.writeMemory.byteCount,
+                        param.writeMemory.flags);
         ops.push_back(param);
 #else
         gds_err("CU_STREAM_MEM_OP_WRITE_MEMORY not supported nor enabled on this GPU\n");
@@ -440,10 +440,10 @@ static int gds_fill_poke(gds_peer *peer, gds_op_list_t &ops, CUdeviceptr addr, u
         if (need_barrier)
                 param.writeValue.flags = 0;
         gds_dbg("op=%d addr=%p value=%08x flags=%08x\n",
-                param.operation,
-                (void*)param.writeValue.address,
-                param.writeValue.value,
-                param.writeValue.flags);
+                        param.operation,
+                        (void*)param.writeValue.address,
+                        param.writeValue.value,
+                        param.writeValue.flags);
         ops.push_back(param);
         return retcode;
 }
@@ -489,10 +489,10 @@ static int gds_fill_poke64(gds_peer *peer, gds_op_list_t &ops, CUdeviceptr addr,
         if (need_barrier)
                 param.writeValue.flags = 0;
         gds_dbg("op=%d addr=%p value=%08x flags=%08x\n",
-                param.operation,
-                (void*)param.writeValue.address,
-                param.writeValue.value,
-                param.writeValue.flags);
+                        param.operation,
+                        (void*)param.writeValue.address,
+                        param.writeValue.value,
+                        param.writeValue.flags);
         ops.push_back(param);
 #else
         gds_err("CU_STREAM_WRITE_VALUE_NO_MEMORY_BARRIER not supported nor enabled on this GPU\n");
@@ -604,50 +604,50 @@ static int gds_fill_poll(gds_peer *peer, gds_op_list_t &ops, CUdeviceptr ptr, ui
         param.waitValue.address = dev_ptr;
         param.waitValue.value = magic;
         switch(cond_flag) {
-        case GDS_WAIT_COND_GEQ:
-                param.waitValue.flags = CU_STREAM_WAIT_VALUE_GEQ;
-                cond_str = "CU_STREAM_WAIT_VALUE_GEQ";
-                break;
-        case GDS_WAIT_COND_EQ:
-                param.waitValue.flags = CU_STREAM_WAIT_VALUE_EQ;
-                cond_str = "CU_STREAM_WAIT_VALUE_EQ";
-                break;
-        case GDS_WAIT_COND_AND:
-                param.waitValue.flags = CU_STREAM_WAIT_VALUE_AND;
-                cond_str = "CU_STREAM_WAIT_VALUE_AND";
-                break;
+                case GDS_WAIT_COND_GEQ:
+                        param.waitValue.flags = CU_STREAM_WAIT_VALUE_GEQ;
+                        cond_str = "CU_STREAM_WAIT_VALUE_GEQ";
+                        break;
+                case GDS_WAIT_COND_EQ:
+                        param.waitValue.flags = CU_STREAM_WAIT_VALUE_EQ;
+                        cond_str = "CU_STREAM_WAIT_VALUE_EQ";
+                        break;
+                case GDS_WAIT_COND_AND:
+                        param.waitValue.flags = CU_STREAM_WAIT_VALUE_AND;
+                        cond_str = "CU_STREAM_WAIT_VALUE_AND";
+                        break;
 
-        case GDS_WAIT_COND_NOR:
+                case GDS_WAIT_COND_NOR:
 #if HAVE_DECL_CU_STREAM_WAIT_VALUE_NOR
-                if (!peer->has_wait_nor) {
-                        gds_err("GDS_WAIT_COND_NOR is not supported nor enabled on this GPU\n");
+                        if (!peer->has_wait_nor) {
+                                gds_err("GDS_WAIT_COND_NOR is not supported nor enabled on this GPU\n");
+                                retcode = EINVAL;
+                                goto out;
+                        }
+                        param.waitValue.flags = CU_STREAM_WAIT_VALUE_NOR;
+                        if (gds_enable_wait_checker())
+                                ck = new poll_checker();
+#else
+                        gds_err("GDS_WAIT_COND_NOR requires CUDA 9.0 at least\n");
+                        retcode = EINVAL;
+#endif
+                        cond_str = "CU_STREAM_WAIT_VALUE_NOR";
+                        break;
+                default: 
+                        gds_err("invalid wait condition flag\n");
                         retcode = EINVAL;
                         goto out;
-                }
-                param.waitValue.flags = CU_STREAM_WAIT_VALUE_NOR;
-                if (gds_enable_wait_checker())
-                        ck = new poll_checker();
-#else
-                gds_err("GDS_WAIT_COND_NOR requires CUDA 9.0 at least\n");
-                retcode = EINVAL;
-#endif
-                cond_str = "CU_STREAM_WAIT_VALUE_NOR";
-                break;
-        default: 
-                gds_err("invalid wait condition flag\n");
-                retcode = EINVAL;
-                goto out;
         }
 
         if (need_flush)
                 param.waitValue.flags |= CU_STREAM_WAIT_VALUE_FLUSH;
 
         gds_dbg("op=%d addr=%p value=%08x cond=%s flags=%08x\n",
-                param.operation,
-                (void*)param.waitValue.address,
-                param.waitValue.value,
-                cond_str,
-                param.waitValue.flags);
+                        param.operation,
+                        (void*)param.waitValue.address,
+                        param.waitValue.value,
+                        cond_str,
+                        param.waitValue.flags);
 
         if (ck)
                 ck->pre(peer, ops, ptr, magic, cond_flag);
@@ -672,7 +672,7 @@ int gds_fill_poll(gds_peer *peer, gds_op_list_t &ops, uint32_t *ptr, uint32_t ma
                 gds_err("could not lookup %p\n", ptr);
                 goto out;
         }
-        
+
         retcode = gds_fill_poll(peer, ops, dev_ptr, magic, cond_flag, flags);
 out:
         return retcode;
@@ -720,35 +720,35 @@ out:
 //-----------------------------------------------------------------------------
 
 /*
-  A) plain+membar:
-  WR32
-  MEMBAR
-  WR32
-  WR32
+   A) plain+membar:
+   WR32
+   MEMBAR
+   WR32
+   WR32
 
-  B) plain:
-  WR32
-  WR32+PREBARRIER
-  WR32
+   B) plain:
+   WR32
+   WR32+PREBARRIER
+   WR32
 
-  C) sim64+membar:
-  WR32
-  MEMBAR
-  INLCPY 8B
+   C) sim64+membar:
+   WR32
+   MEMBAR
+   INLCPY 8B
 
-  D) sim64:
-  INLCPY 4B + POSTBARRIER
-  INLCPY 8B
+   D) sim64:
+   INLCPY 4B + POSTBARRIER
+   INLCPY 8B
 
-  E) inlcpy+membar:
-  WR32
-  MEMBAR
-  INLCPY XB
+   E) inlcpy+membar:
+   WR32
+   MEMBAR
+   INLCPY XB
 
-  F) inlcpy:
-  INLCPY 4B + POSTBARRIER
-  INLCPY 128B
-*/
+   F) inlcpy:
+   INLCPY 4B + POSTBARRIER
+   INLCPY 128B
+ */
 
 int gds_post_ops(gds_peer *peer, size_t n_ops, struct peer_op_wr *op, gds_op_list_t &ops, int post_flags)
 {
@@ -784,190 +784,188 @@ int gds_post_ops(gds_peer *peer, size_t n_ops, struct peer_op_wr *op, gds_op_lis
                 //int flags = 0;
                 gds_dbg("op[%zu] type:%08x\n", n, op->type);
                 switch(op->type) {
-                case IBV_EXP_PEER_OP_FENCE: {
-                        gds_dbg("OP_FENCE: fence_flags=%" PRIu64 "\n", op->wr.fence.fence_flags);
-                        uint32_t fence_op = (op->wr.fence.fence_flags & (IBV_EXP_PEER_FENCE_OP_READ|IBV_EXP_PEER_FENCE_OP_WRITE));
-                        uint32_t fence_from = (op->wr.fence.fence_flags & (IBV_EXP_PEER_FENCE_FROM_CPU|IBV_EXP_PEER_FENCE_FROM_HCA));
-                        uint32_t fence_mem = (op->wr.fence.fence_flags & (IBV_EXP_PEER_FENCE_MEM_SYS|IBV_EXP_PEER_FENCE_MEM_PEER));
+                        case IBV_EXP_PEER_OP_FENCE: {
+                                gds_dbg("OP_FENCE: fence_flags=%" PRIu64 "\n", op->wr.fence.fence_flags);
+                                uint32_t fence_op = (op->wr.fence.fence_flags & (IBV_EXP_PEER_FENCE_OP_READ|IBV_EXP_PEER_FENCE_OP_WRITE));
+                                uint32_t fence_from = (op->wr.fence.fence_flags & (IBV_EXP_PEER_FENCE_FROM_CPU|IBV_EXP_PEER_FENCE_FROM_HCA));
+                                uint32_t fence_mem = (op->wr.fence.fence_flags & (IBV_EXP_PEER_FENCE_MEM_SYS|IBV_EXP_PEER_FENCE_MEM_PEER));
 
-                        if (fence_op == IBV_EXP_PEER_FENCE_OP_READ) {
-                                gds_dbg("nothing to do for read fences\n");
-                                //retcode = EINVAL;
-                                break;
-                        }
-                        else {
-                                if (!peer->has_membar) {
-                                        if (use_inlcpy_for_dword) {
-                                                assert(ops.size() > 0);
-                                                gds_dbg("patching previous param\n");
-                                                gds_enable_barrier_for_inlcpy(&ops.back());
-                                        }
-                                        else {
-                                                gds_dbg("recording fence event\n");
-                                                prev_was_fence = true;
-                                        }
-                                        //retcode = 0;
+                                if (fence_op == IBV_EXP_PEER_FENCE_OP_READ) {
+                                        gds_dbg("nothing to do for read fences\n");
+                                        //retcode = EINVAL;
+                                        break;
                                 }
                                 else {
-                                        if (fence_from != IBV_EXP_PEER_FENCE_FROM_HCA) {
-                                                gds_err("unexpected from fence\n");
-                                                retcode = EINVAL;
-                                                break;
-                                        }
-                                        int flags = 0;
-                                        if (fence_mem == IBV_EXP_PEER_FENCE_MEM_PEER) {
-                                                gds_dbg("using light membar\n");
-                                                flags = GDS_MEMBAR_DEFAULT | GDS_MEMBAR_MLX5;
-                                        }
-                                        else if (fence_mem == IBV_EXP_PEER_FENCE_MEM_SYS) {
-                                                gds_dbg("using heavy membar\n");
-                                                flags = GDS_MEMBAR_SYS | GDS_MEMBAR_MLX5;
+                                        if (!peer->has_membar) {
+                                                if (use_inlcpy_for_dword) {
+                                                        assert(ops.size() > 0);
+                                                        gds_dbg("patching previous param\n");
+                                                        gds_enable_barrier_for_inlcpy(&ops.back());
+                                                }
+                                                else {
+                                                        gds_dbg("recording fence event\n");
+                                                        prev_was_fence = true;
+                                                }
+                                                //retcode = 0;
                                         }
                                         else {
-                                                gds_err("unsupported fence combination\n");
+                                                if (fence_from != IBV_EXP_PEER_FENCE_FROM_HCA) {
+                                                        gds_err("unexpected from fence\n");
+                                                        retcode = EINVAL;
+                                                        break;
+                                                }
+                                                int flags = 0;
+                                                if (fence_mem == IBV_EXP_PEER_FENCE_MEM_PEER) {
+                                                        gds_dbg("using light membar\n");
+                                                        flags = GDS_MEMBAR_DEFAULT | GDS_MEMBAR_MLX5;
+                                                }
+                                                else if (fence_mem == IBV_EXP_PEER_FENCE_MEM_SYS) {
+                                                        gds_dbg("using heavy membar\n");
+                                                        flags = GDS_MEMBAR_SYS | GDS_MEMBAR_MLX5;
+                                                }
+                                                else {
+                                                        gds_err("unsupported fence combination\n");
+                                                        retcode = EINVAL;
+                                                        break;
+                                                }
+                                                retcode = gds_fill_membar(peer, ops, flags);
+                                        }
+                                }
+                                break;
+                        }
+                        case IBV_EXP_PEER_OP_STORE_DWORD: {
+                                CUdeviceptr dev_ptr = range_from_id(op->wr.dword_va.target_id)->dptr + 
+                                        op->wr.dword_va.offset;
+                                uint32_t data = op->wr.dword_va.data;
+                                int flags = 0;
+                                gds_dbg("OP_STORE_DWORD dev_ptr=%llx data=%" PRIx32 "\n", dev_ptr, data);
+                                if (use_inlcpy_for_dword) { // F || D
+                                        // membar may be out of order WRT inlcpy
+                                        if (peer->has_membar) {
+                                                gds_err("invalid feature combination, inlcpy + membar\n");
                                                 retcode = EINVAL;
                                                 break;
                                         }
-                                        retcode = gds_fill_membar(peer, ops, flags);
+                                        // tail flush is set when following fence is met
+                                        //  flags |= GDS_IMMCOPY_POST_TAIL_FLUSH;
+                                        retcode = gds_fill_inlcpy(peer, ops, dev_ptr, &data, sizeof(data), flags);
                                 }
+                                else {  // A || B || C || E
+                                        // can't guarantee ordering of write32+inlcpy unless
+                                        // a membar is there
+                                        // TODO: fix driver when !weak
+                                        if (peer->has_inlcpy && !peer->has_membar) {
+                                                gds_err("invalid feature combination, inlcpy needs membar\n");
+                                                retcode = EINVAL;
+                                                break;
+                                        }
+                                        if (prev_was_fence) {
+                                                gds_dbg("using PRE_BARRIER as fence\n");
+                                                flags |= GDS_WRITE_PRE_BARRIER;
+                                                prev_was_fence = false;
+                                        }
+                                        retcode = gds_fill_poke(peer, ops, dev_ptr, data, flags);
+                                }
+                                break;
                         }
-                        break;
-                }
-                case IBV_EXP_PEER_OP_STORE_DWORD: {
-                        CUdeviceptr dev_ptr = range_from_id(op->wr.dword_va.target_id)->dptr + 
-                                op->wr.dword_va.offset;
-                        uint32_t data = op->wr.dword_va.data;
-                        int flags = 0;
-                        gds_dbg("OP_STORE_DWORD dev_ptr=%llx data=%" PRIx32 "\n", dev_ptr, data);
-                        if (use_inlcpy_for_dword) { // F || D
-                                // membar may be out of order WRT inlcpy
-                                if (peer->has_membar) {
-                                        gds_err("invalid feature combination, inlcpy + membar\n");
+                        case IBV_EXP_PEER_OP_STORE_QWORD: {
+                                CUdeviceptr dev_ptr = range_from_id(op->wr.qword_va.target_id)->dptr +
+                                        op->wr.qword_va.offset;
+                                uint64_t data = op->wr.qword_va.data;
+                                int flags = 0;
+                                gds_dbg("OP_STORE_QWORD dev_ptr=%llx data=%" PRIx64 "\n", dev_ptr, data);
+                                // C || D
+                                if (gds_simulate_write64()) {
+                                        // simulate 64-bit poke by inline copy
+                                        if (!peer->has_membar) {
+                                                gds_err("invalid feature combination, inlcpy needs membar\n");
+                                                retcode = EINVAL;
+                                                break;
+                                        }
+
+                                        // tail flush is never useful here
+                                        //flags |= GDS_IMMCOPY_POST_TAIL_FLUSH;
+                                        retcode = gds_fill_inlcpy(peer, ops, dev_ptr, &data, sizeof(data), flags);
+                                }
+                                else if (peer->has_write64) {
+                                        retcode = gds_fill_poke64(peer, ops, dev_ptr, data, flags);
+                                }
+                                else {
+                                        uint32_t datalo = gds_qword_lo(op->wr.qword_va.data);
+                                        uint32_t datahi = gds_qword_hi(op->wr.qword_va.data);
+
+                                        if (prev_was_fence) {
+                                                gds_dbg("enabling PRE_BARRIER\n");
+                                                flags |= GDS_WRITE_PRE_BARRIER;
+                                                prev_was_fence = false;
+                                        }
+                                        retcode = gds_fill_poke(peer, ops, dev_ptr, datalo, flags);
+
+                                        // get rid of the barrier, if there
+                                        flags &= ~GDS_WRITE_PRE_BARRIER;
+
+                                        // advance to next DWORD
+                                        dev_ptr += sizeof(uint32_t);
+                                        retcode = gds_fill_poke(peer, ops, dev_ptr, datahi, flags);
+                                }
+
+                                break;
+                        }
+                        case IBV_EXP_PEER_OP_COPY_BLOCK: {
+                                CUdeviceptr dev_ptr = range_from_id(op->wr.copy_op.target_id)->dptr + op->wr.copy_op.offset;
+                                size_t len = op->wr.copy_op.len;
+                                void *src = op->wr.copy_op.src;
+                                int flags = 0;
+                                gds_dbg("OP_COPY_BLOCK dev_ptr=%llx src=%p len=%zu\n", dev_ptr, src, len);
+                                // catching any other size here
+                                if (!peer->has_inlcpy) {
+                                        gds_err("inline copy is not supported\n");
                                         retcode = EINVAL;
                                         break;
                                 }
-                                // tail flush is set when following fence is met
-                                //  flags |= GDS_IMMCOPY_POST_TAIL_FLUSH;
-                                retcode = gds_fill_inlcpy(peer, ops, dev_ptr, &data, sizeof(data), flags);
-                        }
-                        else {  // A || B || C || E
-                                // can't guarantee ordering of write32+inlcpy unless
-                                // a membar is there
-                                // TODO: fix driver when !weak
-                                if (peer->has_inlcpy && !peer->has_membar) {
-                                        gds_err("invalid feature combination, inlcpy needs membar\n");
-                                        retcode = EINVAL;
-                                        break;
-                                }
-                                if (prev_was_fence) {
-                                        gds_dbg("using PRE_BARRIER as fence\n");
-                                        flags |= GDS_WRITE_PRE_BARRIER;
-                                        prev_was_fence = false;
-                                }
-                                retcode = gds_fill_poke(peer, ops, dev_ptr, data, flags);
-                        }
-                        break;
-                }
-                case IBV_EXP_PEER_OP_STORE_QWORD: {
-                        CUdeviceptr dev_ptr = range_from_id(op->wr.qword_va.target_id)->dptr +
-                                op->wr.qword_va.offset;
-                        uint64_t data = op->wr.qword_va.data;
-                        int flags = 0;
-                        gds_dbg("OP_STORE_QWORD dev_ptr=%llx data=%" PRIx64 "\n", dev_ptr, data);
-                        // C || D
-                        if (gds_simulate_write64()) {
-                                // simulate 64-bit poke by inline copy
-                                if (!peer->has_membar) {
-                                        gds_err("invalid feature combination, inlcpy needs membar\n");
-                                        retcode = EINVAL;
-                                        break;
-                                }
-
-                                // tail flush is never useful here
-                                //flags |= GDS_IMMCOPY_POST_TAIL_FLUSH;
-                                retcode = gds_fill_inlcpy(peer, ops, dev_ptr, &data, sizeof(data), flags);
-                        }
-                        else if (peer->has_write64) {
-                                retcode = gds_fill_poke64(peer, ops, dev_ptr, data, flags);
-                        }
-                        else {
-                                uint32_t datalo = gds_qword_lo(op->wr.qword_va.data);
-                                uint32_t datahi = gds_qword_hi(op->wr.qword_va.data);
-
-                                if (prev_was_fence) {
-                                        gds_dbg("enabling PRE_BARRIER\n");
-                                        flags |= GDS_WRITE_PRE_BARRIER;
-                                        prev_was_fence = false;
-                                }
-                                retcode = gds_fill_poke(peer, ops, dev_ptr, datalo, flags);
-
-                                // get rid of the barrier, if there
-                                flags &= ~GDS_WRITE_PRE_BARRIER;
-
-                                // advance to next DWORD
-                                dev_ptr += sizeof(uint32_t);
-                                retcode = gds_fill_poke(peer, ops, dev_ptr, datahi, flags);
-                        }
-
-                        break;
-                }
-                case IBV_EXP_PEER_OP_COPY_BLOCK: {
-                        CUdeviceptr dev_ptr = range_from_id(op->wr.copy_op.target_id)->dptr +
-                                op->wr.copy_op.offset;
-                        size_t len = op->wr.copy_op.len;
-                        void *src = op->wr.copy_op.src;
-                        int flags = 0;
-                        gds_dbg("OP_COPY_BLOCK dev_ptr=%llx src=%p len=%zu\n", dev_ptr, src, len);
-                        // catching any other size here
-                        if (!peer->has_inlcpy) {
-                                gds_err("inline copy is not supported\n");
-                                retcode = EINVAL;
+                                // IB Verbs bug
+                                assert(len <= GDS_GPU_MAX_INLINE_SIZE);
+                                //if (desc->need_flush) {
+                                //        flags |= GDS_IMMCOPY_POST_TAIL_FLUSH;
+                                //}
+                                retcode = gds_fill_inlcpy(peer, ops, dev_ptr, src, len, flags);
                                 break;
                         }
-                        // IB Verbs bug
-                        assert(len <= GDS_GPU_MAX_INLINE_SIZE);
-                        //if (desc->need_flush) {
-                        //        flags |= GDS_IMMCOPY_POST_TAIL_FLUSH;
-                        //}
-                        retcode = gds_fill_inlcpy(peer, ops, dev_ptr, src, len, flags);
-                        break;
-                }
-                case IBV_EXP_PEER_OP_POLL_AND_DWORD:
-                case IBV_EXP_PEER_OP_POLL_GEQ_DWORD:
-                case IBV_EXP_PEER_OP_POLL_NOR_DWORD: {
-                        int poll_cond;
-                        CUdeviceptr dev_ptr = range_from_id(op->wr.dword_va.target_id)->dptr + 
-                                op->wr.dword_va.offset;
-                        uint32_t data = op->wr.dword_va.data;
-                        // TODO: properly handle a following fence instead of blidly flushing
-                        int flags = 0;
-                        if (!(post_flags & GDS_POST_OPS_DISCARD_WAIT_FLUSH))
-                                flags |= GDS_WAIT_POST_FLUSH_REMOTE;
-
-                        gds_dbg("OP_WAIT_DWORD dev_ptr=%llx data=%" PRIx32 " type=%" PRIx32 "\n", dev_ptr, data, (uint32_t)op->type);
-
-                        switch(op->type) {
-                        case IBV_EXP_PEER_OP_POLL_NOR_DWORD:
-                                poll_cond = GDS_WAIT_COND_NOR;
-                                break;
-                        case IBV_EXP_PEER_OP_POLL_GEQ_DWORD:
-                                poll_cond = GDS_WAIT_COND_GEQ;
-                                break;
                         case IBV_EXP_PEER_OP_POLL_AND_DWORD:
-                                poll_cond = GDS_WAIT_COND_AND;
+                        case IBV_EXP_PEER_OP_POLL_GEQ_DWORD:
+                        case IBV_EXP_PEER_OP_POLL_NOR_DWORD: {
+                                int poll_cond;
+                                CUdeviceptr dev_ptr = range_from_id(op->wr.dword_va.target_id)->dptr + op->wr.dword_va.offset;
+                                uint32_t data = op->wr.dword_va.data;
+                                // TODO: properly handle a following fence instead of blidly flushing
+                                int flags = 0;
+                                if (!(post_flags & GDS_POST_OPS_DISCARD_WAIT_FLUSH))
+                                        flags |= GDS_WAIT_POST_FLUSH_REMOTE;
+
+                                gds_dbg("OP_WAIT_DWORD dev_ptr=%llx data=%" PRIx32 " type=%" PRIx32 "\n", dev_ptr, data, (uint32_t)op->type);
+
+                                switch(op->type) {
+                                        case IBV_EXP_PEER_OP_POLL_NOR_DWORD:
+                                                poll_cond = GDS_WAIT_COND_NOR;
+                                                break;
+                                        case IBV_EXP_PEER_OP_POLL_GEQ_DWORD:
+                                                poll_cond = GDS_WAIT_COND_GEQ;
+                                                break;
+                                        case IBV_EXP_PEER_OP_POLL_AND_DWORD:
+                                                poll_cond = GDS_WAIT_COND_AND;
+                                                break;
+                                        default:
+                                                assert(!"cannot happen");
+                                                retcode = EINVAL;
+                                                goto out;
+                                }
+                                retcode = gds_fill_poll(peer, ops, dev_ptr, data, poll_cond, flags);
                                 break;
-                        default:
-                                assert(!"cannot happen");
-                                retcode = EINVAL;
-                                goto out;
                         }
-                        retcode = gds_fill_poll(peer, ops, dev_ptr, data, poll_cond, flags);
-                        break;
-                }
-                default:
-                        gds_err("undefined peer op type %d\n", op->type);
-                        retcode = EINVAL;
-                        break;
+                        default:
+                                gds_err("undefined peer op type %d\n", op->type);
+                                retcode = EINVAL;
+                                break;
                 }
                 if (retcode) {
                         gds_err("error in fill func at entry n=%zu\n", n);
@@ -1036,101 +1034,101 @@ int gds_post_ops_on_cpu(size_t n_ops, struct peer_op_wr *op, int post_flags)
                 gds_dbg("op[%zu]=%p\n", n, op);
                 //gds_dbg("op[%zu]=%p type:%08x\n", n, op, op->type);
                 switch(op->type) {
-                case IBV_EXP_PEER_OP_FENCE: {
-                        gds_dbg("FENCE flags=%" PRIu64 "\n", op->wr.fence.fence_flags);
-                        uint32_t fence_op = (op->wr.fence.fence_flags & (IBV_EXP_PEER_FENCE_OP_READ|IBV_EXP_PEER_FENCE_OP_WRITE));
-                        uint32_t fence_from = (op->wr.fence.fence_flags & (IBV_EXP_PEER_FENCE_FROM_CPU|IBV_EXP_PEER_FENCE_FROM_HCA));
-                        uint32_t fence_mem = (op->wr.fence.fence_flags & (IBV_EXP_PEER_FENCE_MEM_SYS|IBV_EXP_PEER_FENCE_MEM_PEER));
+                        case IBV_EXP_PEER_OP_FENCE: {
+                                gds_dbg("FENCE flags=%" PRIu64 "\n", op->wr.fence.fence_flags);
+                                uint32_t fence_op = (op->wr.fence.fence_flags & (IBV_EXP_PEER_FENCE_OP_READ|IBV_EXP_PEER_FENCE_OP_WRITE));
+                                uint32_t fence_from = (op->wr.fence.fence_flags & (IBV_EXP_PEER_FENCE_FROM_CPU|IBV_EXP_PEER_FENCE_FROM_HCA));
+                                uint32_t fence_mem = (op->wr.fence.fence_flags & (IBV_EXP_PEER_FENCE_MEM_SYS|IBV_EXP_PEER_FENCE_MEM_PEER));
 
-                        if (fence_op == IBV_EXP_PEER_FENCE_OP_READ) {
-                                gds_warnc(1, "nothing to do for read fences\n");
-                                //retcode = EINVAL;
-                                break;
-                        }
-                        else {
-                                if (fence_from != IBV_EXP_PEER_FENCE_FROM_HCA) {
-                                        gds_err("unexpected from %08x fence, expected FROM_HCA\n", fence_from);
-                                        retcode = EINVAL;
+                                if (fence_op == IBV_EXP_PEER_FENCE_OP_READ) {
+                                        gds_warnc(1, "nothing to do for read fences\n");
+                                        //retcode = EINVAL;
                                         break;
-                                }
-                                if (fence_mem == IBV_EXP_PEER_FENCE_MEM_PEER) {
-                                        gds_dbg("using light membar\n");
-                                        wmb();
-                                }
-                                else if (fence_mem == IBV_EXP_PEER_FENCE_MEM_SYS) {
-                                        gds_dbg("using heavy membar\n");
-                                        wmb();
                                 }
                                 else {
-                                        gds_err("unsupported fence combination\n");
-                                        retcode = EINVAL;
-                                        break;
+                                        if (fence_from != IBV_EXP_PEER_FENCE_FROM_HCA) {
+                                                gds_err("unexpected from %08x fence, expected FROM_HCA\n", fence_from);
+                                                retcode = EINVAL;
+                                                break;
+                                        }
+                                        if (fence_mem == IBV_EXP_PEER_FENCE_MEM_PEER) {
+                                                gds_dbg("using light membar\n");
+                                                wmb();
+                                        }
+                                        else if (fence_mem == IBV_EXP_PEER_FENCE_MEM_SYS) {
+                                                gds_dbg("using heavy membar\n");
+                                                wmb();
+                                        }
+                                        else {
+                                                gds_err("unsupported fence combination\n");
+                                                retcode = EINVAL;
+                                                break;
+                                        }
                                 }
+                                break;
                         }
-                        break;
-                }
-                case IBV_EXP_PEER_OP_STORE_DWORD: {
-                        uint32_t *ptr = (uint32_t*)((ptrdiff_t)range_from_id(op->wr.dword_va.target_id)->va + op->wr.dword_va.offset);
-                        uint32_t data = op->wr.dword_va.data;
-                        // A || B || C || E
-                        gds_dbg("STORE_DWORD ptr=%p data=%08" PRIx32 "\n", ptr, data);
-                        gds_atomic_set(ptr, data);
-                        break;
-                }
-                case IBV_EXP_PEER_OP_STORE_QWORD: {
-                        uint64_t *ptr = (uint64_t*)((ptrdiff_t)range_from_id(op->wr.qword_va.target_id)->va + op->wr.qword_va.offset);
-                        uint64_t data = op->wr.qword_va.data;
-                        gds_dbg("STORE_QWORD ptr=%p data=%016" PRIx64 "\n", ptr, data);
-                        gds_atomic_set(ptr, data);
-                        break;
-                }
-                case IBV_EXP_PEER_OP_COPY_BLOCK: {
-                        uint64_t *ptr = (uint64_t*)((ptrdiff_t)range_from_id(op->wr.copy_op.target_id)->va + op->wr.copy_op.offset);
-                        uint64_t *src = (uint64_t*)op->wr.copy_op.src;
-                        size_t n_bytes = op->wr.copy_op.len;
-                        gds_dbg("COPY_BLOCK ptr=%p src=%p len=%zu\n", ptr, src, n_bytes);
-                        gds_bf_copy(ptr, src, n_bytes);
-                        break;
-                }
-                case IBV_EXP_PEER_OP_POLL_AND_DWORD:
-                case IBV_EXP_PEER_OP_POLL_GEQ_DWORD:
-                case IBV_EXP_PEER_OP_POLL_NOR_DWORD: {
-                        int poll_cond;
-                        uint32_t *ptr = (uint32_t*)((ptrdiff_t)range_from_id(op->wr.dword_va.target_id)->va + op->wr.dword_va.offset);
-                        uint32_t value = op->wr.dword_va.data;
-                        bool flush = true;
-                        if (post_flags & GDS_POST_OPS_DISCARD_WAIT_FLUSH)
-                                flush = false;
-                        gds_dbg("WAIT_32 dev_ptr=%p data=%" PRIx32 " type=%" PRIx32 "\n", ptr, value, (uint32_t)op->type);
-                        bool done = false;
-                        do {
-                                uint32_t data = gds_atomic_get(ptr);
-                                switch(op->type) {
-                                case IBV_EXP_PEER_OP_POLL_NOR_DWORD:
-                                        done = (0 != ~(data | value));
-                                        break;
-                                case IBV_EXP_PEER_OP_POLL_GEQ_DWORD:
-                                        done = ((int32_t)data - (int32_t)value >= 0);
-                                        break;
-                                case IBV_EXP_PEER_OP_POLL_AND_DWORD:
-                                        done = (0 != (data & value));
-                                        break;
-                                default:
-                                        gds_err("invalid op type %02x\n", op->type);
-                                        retcode = EINVAL;
-                                        goto out;
-                                }
-                                if (done)
-                                        break;
-                                // TODO: more aggressive CPU relaxing needed here to avoid starving I/O fabric
-                                arch_cpu_relax();
-                        } while(true);
-                        break;
-                }
-                default:
-                        gds_err("undefined peer op type %d\n", op->type);
-                        retcode = EINVAL;
-                        break;
+                        case IBV_EXP_PEER_OP_STORE_DWORD: {
+                                uint32_t *ptr = (uint32_t*)((ptrdiff_t)range_from_id(op->wr.dword_va.target_id)->va + op->wr.dword_va.offset);
+                                uint32_t data = op->wr.dword_va.data;
+                                // A || B || C || E
+                                gds_dbg("STORE_DWORD ptr=%p data=%08" PRIx32 "\n", ptr, data);
+                                gds_atomic_set(ptr, data);
+                                break;
+                        }
+                        case IBV_EXP_PEER_OP_STORE_QWORD: {
+                                uint64_t *ptr = (uint64_t*)((ptrdiff_t)range_from_id(op->wr.qword_va.target_id)->va + op->wr.qword_va.offset);
+                                uint64_t data = op->wr.qword_va.data;
+                                gds_dbg("STORE_QWORD ptr=%p data=%016" PRIx64 "\n", ptr, data);
+                                gds_atomic_set(ptr, data);
+                                break;
+                        }
+                        case IBV_EXP_PEER_OP_COPY_BLOCK: {
+                                uint64_t *ptr = (uint64_t*)((ptrdiff_t)range_from_id(op->wr.copy_op.target_id)->va + op->wr.copy_op.offset);
+                                uint64_t *src = (uint64_t*)op->wr.copy_op.src;
+                                size_t n_bytes = op->wr.copy_op.len;
+                                gds_dbg("COPY_BLOCK ptr=%p src=%p len=%zu\n", ptr, src, n_bytes);
+                                gds_bf_copy(ptr, src, n_bytes);
+                                break;
+                        }
+                        case IBV_EXP_PEER_OP_POLL_AND_DWORD:
+                        case IBV_EXP_PEER_OP_POLL_GEQ_DWORD:
+                        case IBV_EXP_PEER_OP_POLL_NOR_DWORD: {
+                                int poll_cond;
+                                uint32_t *ptr = (uint32_t*)((ptrdiff_t)range_from_id(op->wr.dword_va.target_id)->va + op->wr.dword_va.offset);
+                                uint32_t value = op->wr.dword_va.data;
+                                bool flush = true;
+                                if (post_flags & GDS_POST_OPS_DISCARD_WAIT_FLUSH)
+                                        flush = false;
+                                gds_dbg("WAIT_32 dev_ptr=%p data=%" PRIx32 " type=%" PRIx32 "\n", ptr, value, (uint32_t)op->type);
+                                bool done = false;
+                                do {
+                                        uint32_t data = gds_atomic_get(ptr);
+                                        switch(op->type) {
+                                                case IBV_EXP_PEER_OP_POLL_NOR_DWORD:
+                                                        done = (0 != ~(data | value));
+                                                        break;
+                                                case IBV_EXP_PEER_OP_POLL_GEQ_DWORD:
+                                                        done = ((int32_t)data - (int32_t)value >= 0);
+                                                        break;
+                                                case IBV_EXP_PEER_OP_POLL_AND_DWORD:
+                                                        done = (0 != (data & value));
+                                                        break;
+                                                default:
+                                                        gds_err("invalid op type %02x\n", op->type);
+                                                        retcode = EINVAL;
+                                                        goto out;
+                                        }
+                                        if (done)
+                                                break;
+                                        // TODO: more aggressive CPU relaxing needed here to avoid starving I/O fabric
+                                        arch_cpu_relax();
+                                } while(true);
+                                break;
+                        }
+                        default:
+                                gds_err("undefined peer op type %d\n", op->type);
+                                retcode = EINVAL;
+                                break;
                 }
                 if (retcode) {
                         gds_err("error %d at entry n=%zu\n", retcode, n);
@@ -1176,50 +1174,46 @@ static void gds_dump_ops(struct peer_op_wr *op, size_t count)
         for (; op; op = op->next, ++n) {
                 gds_dbg("op[%zu] type:%d\n", n, op->type);
                 switch(op->type) {
-                case IBV_EXP_PEER_OP_FENCE: {
-                        gds_dbg("FENCE flags=%" PRIu64 "\n", op->wr.fence.fence_flags);
-                        break;
-                }
-                case IBV_EXP_PEER_OP_STORE_DWORD: {
-                        CUdeviceptr dev_ptr = range_from_id(op->wr.dword_va.target_id)->dptr + 
-                                op->wr.dword_va.offset;
-                        gds_dbg("STORE_QWORD data:%x target_id:%" PRIx64 " offset:%zu dev_ptr=%llx\n",
-                                op->wr.dword_va.data, op->wr.dword_va.target_id,
-                                op->wr.dword_va.offset, dev_ptr);
-                        break;
-                }
-                case IBV_EXP_PEER_OP_STORE_QWORD: {
-                        CUdeviceptr dev_ptr = range_from_id(op->wr.qword_va.target_id)->dptr +
-                                op->wr.qword_va.offset;
-                        gds_dbg("STORE_QWORD data:%" PRIx64 " target_id:%" PRIx64 " offset:%zu dev_ptr=%llx\n",
-                                op->wr.qword_va.data, op->wr.qword_va.target_id,
-                                op->wr.qword_va.offset, dev_ptr);
-                        break;
-                }
-                case IBV_EXP_PEER_OP_COPY_BLOCK: {
-                        CUdeviceptr dev_ptr = range_from_id(op->wr.copy_op.target_id)->dptr +
-                                op->wr.copy_op.offset;
-                        gds_dbg("COPY_BLOCK src:%p len:%zu target_id:%" PRIx64 " offset:%zu dev_ptr=%llx\n",
-                                op->wr.copy_op.src, op->wr.copy_op.len,
-                                op->wr.copy_op.target_id, op->wr.copy_op.offset,
-                                dev_ptr);
-                        break;
-                }
-                case IBV_EXP_PEER_OP_POLL_AND_DWORD:
-                case IBV_EXP_PEER_OP_POLL_NOR_DWORD: {
-                        CUdeviceptr dev_ptr = range_from_id(op->wr.dword_va.target_id)->dptr + 
-                                op->wr.dword_va.offset;
-                        gds_dbg("%s data:%08x target_id:%" PRIx64 " offset:%zu dev_ptr=%llx\n", 
-                                (op->type==IBV_EXP_PEER_OP_POLL_AND_DWORD) ? "POLL_AND_DW" : "POLL_NOR_SDW",
-                                op->wr.dword_va.data, 
-                                op->wr.dword_va.target_id, 
-                                op->wr.dword_va.offset, 
-                                dev_ptr);
-                        break;
-                }
-                default:
-                        gds_err("undefined peer op type %d\n", op->type);
-                        break;
+                        case IBV_EXP_PEER_OP_FENCE: {
+                                gds_dbg("FENCE flags=%" PRIu64 "\n", op->wr.fence.fence_flags);
+                                break;
+                        }
+                        case IBV_EXP_PEER_OP_STORE_DWORD: {
+                                CUdeviceptr dev_ptr = range_from_id(op->wr.dword_va.target_id)->dptr + op->wr.dword_va.offset;
+                                gds_dbg("STORE_QWORD data:%x target_id:%" PRIx64 " offset:%zu dev_ptr=%llx\n",
+                                                op->wr.dword_va.data, op->wr.dword_va.target_id,
+                                                op->wr.dword_va.offset, dev_ptr);
+                                break;
+                        }
+                        case IBV_EXP_PEER_OP_STORE_QWORD: {
+                                CUdeviceptr dev_ptr = range_from_id(op->wr.qword_va.target_id)->dptr +
+                                        op->wr.qword_va.offset; gds_dbg("STORE_QWORD data:%" PRIx64 " target_id:%" PRIx64 " offset:%zu dev_ptr=%llx\n",
+                                                op->wr.qword_va.data, op->wr.qword_va.target_id,
+                                                op->wr.qword_va.offset, dev_ptr);
+                                break;
+                        }
+                        case IBV_EXP_PEER_OP_COPY_BLOCK: {
+                                CUdeviceptr dev_ptr = range_from_id(op->wr.copy_op.target_id)->dptr + op->wr.copy_op.offset;
+                                gds_dbg("COPY_BLOCK src:%p len:%zu target_id:%" PRIx64 " offset:%zu dev_ptr=%llx\n",
+                                                op->wr.copy_op.src, op->wr.copy_op.len,
+                                                op->wr.copy_op.target_id, op->wr.copy_op.offset,
+                                                dev_ptr);
+                                break;
+                        }
+                        case IBV_EXP_PEER_OP_POLL_AND_DWORD:
+                        case IBV_EXP_PEER_OP_POLL_NOR_DWORD: {
+                                CUdeviceptr dev_ptr = range_from_id(op->wr.dword_va.target_id)->dptr + op->wr.dword_va.offset;
+                                gds_dbg("%s data:%08x target_id:%" PRIx64 " offset:%zu dev_ptr=%llx\n", 
+                                                (op->type==IBV_EXP_PEER_OP_POLL_AND_DWORD) ? "POLL_AND_DW" : "POLL_NOR_SDW",
+                                                op->wr.dword_va.data, 
+                                                op->wr.dword_va.target_id, 
+                                                op->wr.dword_va.offset, 
+                                                dev_ptr);
+                                break;
+                        }
+                        default:
+                                gds_err("undefined peer op type %d\n", op->type);
+                                break;
                 }
         }
 
@@ -1233,8 +1227,8 @@ void gds_dump_wait_request(gds_wait_request_s *request, size_t count)
         for (size_t j=0; j<count; ++j) {
                 struct ibv_exp_peer_peek *peek = &request[j].peek;
                 gds_dbg("req[%zu] entries:%u whence:%u offset:%u peek_id:%" PRIx64 " comp_mask:%08x\n", 
-                        j, peek->entries, peek->whence, peek->offset, 
-                        peek->peek_id, peek->comp_mask);
+                                j, peek->entries, peek->whence, peek->offset, 
+                                peek->peek_id, peek->comp_mask);
                 gds_dump_ops(peek->storage, peek->entries);
         }
 }
@@ -1243,44 +1237,44 @@ void gds_dump_wait_request(gds_wait_request_s *request, size_t count)
 
 int gds_stream_post_wait_cq_multi(CUstream stream, int count, gds_wait_request_t *request, uint32_t *dw, uint32_t val)
 {
-    int retcode = 0;
-    int n_mem_ops = 0;
-    int idx = 0;
-    int k=0;
-    gds_descriptor_t *descs = NULL;
+        int retcode = 0;
+        int n_mem_ops = 0;
+        int idx = 0;
+        int k=0;
+        gds_descriptor_t *descs = NULL;
 
-    assert(request);
-    assert(count);
+        assert(request);
+        assert(count);
 
-    descs = (gds_descriptor_t *)calloc(count, sizeof(gds_descriptor_t));
-    if(!descs)
-    {
-        gds_err("Calloc for %d elements\n", count);
-        retcode = ENOMEM;
-        goto out;
-    }
+        descs = (gds_descriptor_t *)calloc(count, sizeof(gds_descriptor_t));
+        if (!descs)
+        {
+                gds_err("Calloc for %d elements\n", count);
+                retcode = ENOMEM;
+                goto out;
+        }
 
-    for (k=0; k<count; k++) {
-        descs[k].tag = GDS_TAG_WAIT;
-        descs[k].wait = &request[k];
-    }
+        for (k=0; k<count; k++) {
+                descs[k].tag = GDS_TAG_WAIT;
+                descs[k].wait = &request[k];
+        }
 
-    retcode=gds_stream_post_descriptors(stream, count, descs, 0);
-    if (retcode) {
-        gds_err("error %d in gds_stream_post_descriptors\n", retcode);
-        goto out;
-    }
+        retcode = gds_stream_post_descriptors(stream, count, descs, 0);
+        if (retcode) {
+                gds_err("error %d in gds_stream_post_descriptors\n", retcode);
+                goto out;
+        }
 
 out:
-    if (descs) 
-        free(descs);
-    for (k = 0; k < count; ++k) {
-        if (request[k].handle != NULL && !(to_gds_wait_request_s(&request[k])->flags & GDS_FLAG_INTERNAL_KEEP_REQUESTS)) {
-            free(request[k].handle);
-            request[k].handle = NULL;
+        if (descs) 
+                free(descs);
+        for (k = 0; k < count; ++k) {
+                if (request[k].handle != NULL && !(to_gds_wait_request_s(&request[k])->flags & GDS_FLAG_INTERNAL_KEEP_REQUESTS)) {
+                        free(request[k].handle);
+                        request[k].handle = NULL;
+                }
         }
-    }
-    return retcode;
+        return retcode;
 }
 
 //-----------------------------------------------------------------------------
@@ -1295,7 +1289,7 @@ static struct ibv_exp_peer_buf *gds_buf_alloc(ibv_exp_peer_buf_alloc_attr *attr)
         assert(peer);
 
         gds_dbg("alloc mem peer:{type=%d gpu_id=%d} attr{len=%zu dir=%d alignment=%d peer_id=%" PRIx64 "}\n",
-                peer->alloc_type, peer->gpu_id, attr->length, attr->dir, attr->alignment, attr->peer_id);
+                        peer->alloc_type, peer->gpu_id, attr->length, attr->dir, attr->alignment, attr->peer_id);
 
         return peer->buf_alloc(peer->alloc_type, attr->length, attr->dir, attr->alignment, peer->alloc_flags);
 }
@@ -1444,7 +1438,7 @@ static bool support_weak_consistency(CUdevice dev)
 
         do {
                 gds_dbg("testing hidden weak flag\n");
-                        
+
                 CUstreamBatchMemOpParams params[2];
                 CUresult res;
                 res = cuStreamBatchMemOp(0, 0, params, 0);
@@ -1519,9 +1513,9 @@ static void gds_init_peer(gds_peer *peer, CUdevice dev, int gpu_id)
         peer->attr.unregister_va = gds_unregister_va;
 
         peer->attr.caps = ( IBV_EXP_PEER_OP_STORE_DWORD_CAP    | 
-                            IBV_EXP_PEER_OP_STORE_QWORD_CAP    | 
-                            IBV_EXP_PEER_OP_FENCE_CAP          | 
-                            IBV_EXP_PEER_OP_POLL_AND_DWORD_CAP );
+                        IBV_EXP_PEER_OP_STORE_QWORD_CAP    | 
+                        IBV_EXP_PEER_OP_FENCE_CAP          | 
+                        IBV_EXP_PEER_OP_POLL_AND_DWORD_CAP );
 
         if (peer->has_wait_nor) {
                 gds_dbg("enabling NOR feature\n");
@@ -1556,7 +1550,7 @@ static int gds_register_peer(CUdevice dev, unsigned gpu_id, gds_peer **p_peer, g
         int ret = 0;
 
         gds_dbg("GPU%u: registering peer\n", gpu_id);
-        
+
         if (gpu_id >= max_gpus) {
                 gds_err("invalid gpu_id %d\n", gpu_id);
                 return EINVAL;
@@ -1710,11 +1704,11 @@ static ibv_exp_res_domain *gds_create_res_domain(struct ibv_context *context)
 
 //-----------------------------------------------------------------------------
 
-static gds_cq_t *
+        static gds_cq_t *
 gds_create_cq_internal(struct ibv_context *context, int cqe,
-                        void *cq_context, struct ibv_comp_channel *channel,
-                        int comp_vector, int gpu_id, gds_alloc_cq_flags_t flags,
-                        struct ibv_exp_res_domain * res_domain)
+                void *cq_context, struct ibv_comp_channel *channel,
+                int comp_vector, int gpu_id, gds_alloc_cq_flags_t flags,
+                struct ibv_exp_res_domain * res_domain)
 {
         gds_cq_t *gcq = NULL;
         ibv_exp_cq_init_attr attr;
@@ -1724,22 +1718,22 @@ gds_create_cq_internal(struct ibv_context *context, int cqe,
 
         if(!context)
         {
-            gds_dbg("Invalid input context\n");
-            return NULL;
+                gds_dbg("Invalid input context\n");
+                return NULL;
         }
 
         gcq = (gds_cq_t*)calloc(1, sizeof(gds_cq_t));
         if (!gcq) {
-            gds_err("cannot allocate memory\n");
-            return NULL;
+                gds_err("cannot allocate memory\n");
+                return NULL;
         }
 
         //Here we need to recover peer and peer_attr pointers to set alloc_type and alloc_flags
         //before ibv_exp_create_cq
         ret = gds_register_peer_by_ordinal(gpu_id, &peer, &peer_attr);
         if (ret) {
-            gds_err("error %d while registering GPU peer\n", ret);
-            return NULL;
+                gds_err("error %d while registering GPU peer\n", ret);
+                return NULL;
         }
         assert(peer);
         assert(peer_attr);
@@ -1751,26 +1745,26 @@ gds_create_cq_internal(struct ibv_context *context, int cqe,
         attr.flags = 0; // see ibv_exp_cq_create_flags
         attr.peer_direct_attrs = peer_attr;
         if (res_domain) {
-            gds_dbg("using peer->res_domain %p for CQ\n", res_domain);
-            attr.res_domain = res_domain;
-            attr.comp_mask |= IBV_EXP_CQ_INIT_ATTR_RES_DOMAIN;
+                gds_dbg("using peer->res_domain %p for CQ\n", res_domain);
+                attr.res_domain = res_domain;
+                attr.comp_mask |= IBV_EXP_CQ_INIT_ATTR_RES_DOMAIN;
         }
-        
+
         int old_errno = errno;
         gcq->cq = ibv_exp_create_cq(context, cqe, cq_context, channel, comp_vector, &attr);
         if (!gcq->cq) {
-            gds_err("error %d in ibv_exp_create_cq, old errno %d\n", errno, old_errno);
-            return NULL;
+                gds_err("error %d in ibv_exp_create_cq, old errno %d\n", errno, old_errno);
+                return NULL;
         }
 
         return gcq;
 }
 
 //Note: general create cq function, not really used for now!
-gds_cq_t *
+        gds_cq_t *
 gds_create_cq(struct ibv_context *context, int cqe,
-              void *cq_context, struct ibv_comp_channel *channel,
-              int comp_vector, int gpu_id, gds_alloc_cq_flags_t flags)
+                void *cq_context, struct ibv_comp_channel *channel,
+                int comp_vector, int gpu_id, gds_alloc_cq_flags_t flags)
 {
         int ret = 0;
         gds_cq_t *gcq = NULL;
@@ -1793,16 +1787,16 @@ gds_create_cq(struct ibv_context *context, int cqe,
 
         res_domain = gds_create_res_domain(context);
         if (res_domain)
-            gds_dbg("using res_domain %p\n", res_domain);
+                gds_dbg("using res_domain %p\n", res_domain);
         else
-            gds_warn("NOT using res_domain\n");
+                gds_warn("NOT using res_domain\n");
 
-        
+
         gcq = gds_create_cq_internal(context, cqe, cq_context, channel, comp_vector, gpu_id, flags, res_domain);
 
         if (!gcq) {
-            gds_err("error in gds_create_cq_internal\n");
-            return NULL;
+                gds_err("error in gds_create_cq_internal\n");
+                return NULL;
         }
 
         return gcq;
@@ -1811,7 +1805,7 @@ gds_create_cq(struct ibv_context *context, int cqe,
 //-----------------------------------------------------------------------------
 
 gds_qp_t *gds_create_qp(struct ibv_pd *pd, struct ibv_context *context,
-                        gds_qp_init_attr_t *qp_attr, int gpu_id, int flags)
+                gds_qp_init_attr_t *qp_attr, int gpu_id, int flags)
 {
         int ret = 0;
         gds_qp_internal_t *gqpi = NULL;
@@ -1848,8 +1842,8 @@ gds_qp_t *gds_create_qp(struct ibv_pd *pd, struct ibv_context *context,
 
         gqpi = (gds_qp_internal_t *)calloc(1, sizeof(gds_qp_internal_t));
         if (!gqpi) {
-            gds_err("cannot allocate memory\n");
-            return NULL;
+                gds_err("cannot allocate memory\n");
+                return NULL;
         }
 
         gqp = &gqpi->gqp;
@@ -1860,19 +1854,19 @@ gds_qp_t *gds_create_qp(struct ibv_pd *pd, struct ibv_context *context,
         gds_dbg("before gds_register_peer_ex\n");
         ret = gds_register_peer_by_ordinal(gpu_id, &peer, &peer_attr);
         if (ret) {
-            gds_err("error %d in gds_register_peer_ex\n", ret);
-            goto err;
+                gds_err("error %d in gds_register_peer_ex\n", ret);
+                goto err;
         }
 
         gqpi->res_domain = gds_create_res_domain(context);
         if (gqpi->res_domain)
-            gds_dbg("using res_domain %p\n", gqpi->res_domain);
+                gds_dbg("using res_domain %p\n", gqpi->res_domain);
         else
-            gds_warn("NOT using res_domain\n");
+                gds_warn("NOT using res_domain\n");
 
         tx_gcq = gds_create_cq_internal(context, exp_qp_attr.cap.max_send_wr, NULL, NULL, 0, gpu_id, 
-                              (flags & GDS_CREATE_QP_TX_CQ_ON_GPU) ? GDS_ALLOC_CQ_ON_GPU : GDS_ALLOC_CQ_DEFAULT, 
-                              gqpi->res_domain);
+                        (flags & GDS_CREATE_QP_TX_CQ_ON_GPU) ? GDS_ALLOC_CQ_ON_GPU : GDS_ALLOC_CQ_DEFAULT, 
+                        gqpi->res_domain);
         if (!tx_gcq) {
                 ret = errno;
                 gds_err("error %d while creating TX CQ, old_errno=%d\n", ret, old_errno);
@@ -1880,8 +1874,8 @@ gds_qp_t *gds_create_qp(struct ibv_pd *pd, struct ibv_context *context,
         }
 
         rx_gcq = gds_create_cq_internal(context, exp_qp_attr.cap.max_recv_wr, NULL, NULL, 0, gpu_id, 
-                              (flags & GDS_CREATE_QP_RX_CQ_ON_GPU) ? GDS_ALLOC_CQ_ON_GPU : GDS_ALLOC_CQ_DEFAULT, 
-                              gqpi->res_domain);
+                        (flags & GDS_CREATE_QP_RX_CQ_ON_GPU) ? GDS_ALLOC_CQ_ON_GPU : GDS_ALLOC_CQ_DEFAULT, 
+                        gqpi->res_domain);
         if (!rx_gcq) {
                 ret = errno;
                 gds_err("error %d while creating RX CQ\n", ret);
@@ -1939,46 +1933,46 @@ int gds_destroy_qp(gds_qp_t *gqp)
         int ret;
 
         gds_qp_internal_t *gqpi;
-        
+
         if(!gqp) return retcode;
 
         gqpi = container_of(gqp, gds_qp_internal_t, gqp);
 
         if(gqp->qp)
         {
-            ret = ibv_destroy_qp(gqp->qp);
-            if (ret) {
-                    gds_err("error %d in destroy_qp\n", ret);
-                    retcode = ret;
-            }            
+                ret = ibv_destroy_qp(gqp->qp);
+                if (ret) {
+                        gds_err("error %d in destroy_qp\n", ret);
+                        retcode = ret;
+                }            
         }
 
         if(gqp->send_cq.cq)
         {
-            ret = ibv_destroy_cq(gqp->send_cq.cq);
-            if (ret) {
-                    gds_err("error %d in destroy_cq send_cq\n", ret);
-                    retcode = ret;
-            }
+                ret = ibv_destroy_cq(gqp->send_cq.cq);
+                if (ret) {
+                        gds_err("error %d in destroy_cq send_cq\n", ret);
+                        retcode = ret;
+                }
         }
 
         if(gqp->recv_cq.cq)
         {
-            ret = ibv_destroy_cq(gqp->recv_cq.cq);
-            if (ret) {
-                    gds_err("error %d in destroy_cq recv_cq\n", ret);
-                    retcode = ret;
-            }
+                ret = ibv_destroy_cq(gqp->recv_cq.cq);
+                if (ret) {
+                        gds_err("error %d in destroy_cq recv_cq\n", ret);
+                        retcode = ret;
+                }
         }
 
         if(gqpi->res_domain) {
-            struct ibv_exp_destroy_res_domain_attr attr; //IBV_EXP_DESTROY_RES_DOMAIN_RESERVED
-            attr.comp_mask=0;
-            ret = ibv_exp_destroy_res_domain(gqp->dev_context, gqpi->res_domain, &attr);
-            if (ret) {
-                    gds_err("ibv_exp_destroy_res_domain error %d: %s\n", ret, strerror(ret));
-                    retcode = ret;
-            }            
+                struct ibv_exp_destroy_res_domain_attr attr; //IBV_EXP_DESTROY_RES_DOMAIN_RESERVED
+                attr.comp_mask=0;
+                ret = ibv_exp_destroy_res_domain(gqp->dev_context, gqpi->res_domain, &attr);
+                if (ret) {
+                        gds_err("ibv_exp_destroy_res_domain error %d: %s\n", ret, strerror(ret));
+                        retcode = ret;
+                }            
         }
 
         free(gqpi);
@@ -1995,12 +1989,12 @@ int gds_query_param(gds_param_t param, int *value)
                 return EINVAL;
 
         switch (param) {
-        case GDS_PARAM_VERSION:
-                *value = (GDS_API_MAJOR_VERSION << 16)|GDS_API_MINOR_VERSION;
-                break;
-        default:
-                ret = EINVAL;
-                break;
+                case GDS_PARAM_VERSION:
+                        *value = (GDS_API_MAJOR_VERSION << 16)|GDS_API_MINOR_VERSION;
+                        break;
+                default:
+                        ret = EINVAL;
+                        break;
         };
         return ret;
 }

--- a/src/gdsync_debug_hostregister_bug.cpp
+++ b/src/gdsync_debug_hostregister_bug.cpp
@@ -1485,10 +1485,10 @@ gds_create_cq(struct ibv_context *context, int cqe,
 
 //-----------------------------------------------------------------------------
 
-struct gds_qp *gds_create_qp(struct ibv_pd *pd, struct ibv_context *context, gds_qp_init_attr_t *qp_attr, int gpu_id, int flags)
+gds_qp_t *gds_create_qp(struct ibv_pd *pd, struct ibv_context *context, gds_qp_init_attr_t *qp_attr, int gpu_id, int flags)
 {
         int ret = 0;
-        struct gds_qp *gqp = NULL;
+        gds_qp_t *gqp = NULL;
         struct ibv_qp *qp = NULL;
         struct ibv_cq *rx_cq = NULL, *tx_cq = NULL;
         gds_peer *peer = NULL;
@@ -1500,7 +1500,7 @@ struct gds_qp *gds_create_qp(struct ibv_pd *pd, struct ibv_context *context, gds
         assert(context);
         assert(qp_attr);
 
-        gqp = (struct gds_qp*)calloc(1, sizeof(struct gds_qp));
+        gqp = (gds_qp_t *)calloc(1, sizeof(gds_qp_t));
         if (!gqp) {
                 gds_err("cannot allocate memory\n");
                 return NULL;
@@ -1609,7 +1609,7 @@ err:
 
 //-----------------------------------------------------------------------------
 
-int gds_destroy_qp(struct gds_qp *qp)
+int gds_destroy_qp(gds_qp_t *qp)
 {
         int retcode = 0;
         int ret;

--- a/src/mem.cpp
+++ b/src/mem.cpp
@@ -125,7 +125,7 @@ static int gds_map_gdr_memory(gds_mem_desc_t *desc, CUdeviceptr d_buf, size_t si
         desc->alloc_size = buf_size;
         desc->mh = mh;
         gds_dbg("d_ptr=%lx h_ptr=%p bar_ptr=%p flags=0x%08x alloc_size=%zd mh=%x\n",
-                (unsigned long)desc->d_ptr, desc->h_ptr, desc->bar_ptr, desc->flags, desc->alloc_size, desc->mh);
+                        (unsigned long)desc->d_ptr, desc->h_ptr, desc->bar_ptr, desc->flags, desc->alloc_size, desc->mh);
 out:
         if (ret) {
                 if (mh) {
@@ -152,7 +152,7 @@ static int gds_unmap_gdr_memory(gds_mem_desc_t *desc)
                 return EINVAL;
         }
         gds_dbg("d_ptr=%lx h_ptr=%p alloc_size=%zd mh=%x\n",
-                (unsigned long)desc->d_ptr, desc->h_ptr, desc->alloc_size, desc->mh);
+                        (unsigned long)desc->d_ptr, desc->h_ptr, desc->alloc_size, desc->mh);
         gdr_unmap(gdr, desc->mh, desc->bar_ptr, desc->alloc_size);
         gdr_unpin_buffer(gdr, desc->mh);
         return ret;
@@ -191,7 +191,7 @@ static int gds_free_gdr_memory(gds_mem_desc_t *desc)
                 return EINVAL;
         }
         gds_dbg("d_ptr=%lx h_ptr=%p alloc_size=%zd mh=%x\n",
-                (unsigned long)desc->d_ptr, desc->h_ptr, desc->alloc_size, desc->mh);
+                        (unsigned long)desc->d_ptr, desc->h_ptr, desc->alloc_size, desc->mh);
 
         ret = gds_unmap_gdr_memory(desc);
         if (ret) {
@@ -245,7 +245,7 @@ static int gds_alloc_pinned_memory(gds_mem_desc_t *desc, size_t size, int flags)
         desc->alloc_size = size;
         desc->mh = 0;        
         gds_dbg("d_ptr=%lx h_ptr=%p flags=0x%08x alloc_size=%zd\n",
-                (unsigned long)desc->d_ptr, desc->h_ptr, desc->flags, desc->alloc_size);
+                        (unsigned long)desc->d_ptr, desc->h_ptr, desc->flags, desc->alloc_size);
 out:
         if (ret) {
                 if (desc->h_ptr) {
@@ -272,7 +272,7 @@ static int gds_free_pinned_memory(gds_mem_desc_t *desc)
         // BUG: TBD
 #else
         gds_dbg("d_ptr=%lx h_ptr=%p flags=0x%08x alloc_size=%zd\n",
-                (unsigned long)desc->d_ptr, desc->h_ptr, desc->flags, desc->alloc_size);
+                        (unsigned long)desc->d_ptr, desc->h_ptr, desc->flags, desc->alloc_size);
         ret = gds_unregister_mem(desc->h_ptr, desc->alloc_size);
         free(desc->h_ptr);
         desc->h_ptr = NULL;
@@ -296,16 +296,16 @@ int gds_alloc_mapped_memory(gds_mem_desc_t *desc, size_t size, int flags)
                 return EINVAL;
         }
         switch(flags & GDS_MEMORY_MASK) {
-        case GDS_MEMORY_GPU:
-                ret = gds_alloc_gdr_memory(desc, size, flags);
-                break;
-        case GDS_MEMORY_HOST:
-                ret = gds_alloc_pinned_memory(desc, size, flags);
-                break;
-        default:
-                gds_err("invalid flags\n");
-                ret = EINVAL;
-                break;
+                case GDS_MEMORY_GPU:
+                        ret = gds_alloc_gdr_memory(desc, size, flags);
+                        break;
+                case GDS_MEMORY_HOST:
+                        ret = gds_alloc_pinned_memory(desc, size, flags);
+                        break;
+                default:
+                        gds_err("invalid flags\n");
+                        ret = EINVAL;
+                        break;
         }
         return ret;
 }
@@ -320,15 +320,15 @@ int gds_free_mapped_memory(gds_mem_desc_t *desc)
                 return EINVAL;
         }
         switch(desc->flags & GDS_MEMORY_MASK) {
-        case GDS_MEMORY_GPU:
-                ret = gds_free_gdr_memory(desc);
-                break;
-        case GDS_MEMORY_HOST:
-                ret = gds_free_pinned_memory(desc);
-                break;
-        default:
-                ret = EINVAL;
-                break;
+                case GDS_MEMORY_GPU:
+                        ret = gds_free_gdr_memory(desc);
+                        break;
+                case GDS_MEMORY_HOST:
+                        ret = gds_free_pinned_memory(desc);
+                        break;
+                default:
+                        ret = EINVAL;
+                        break;
         }
         return ret;
 }

--- a/src/memmgr.cpp
+++ b/src/memmgr.cpp
@@ -77,11 +77,11 @@ static int gds_register_mem_internal(void *ptr, size_t size, gds_memory_type_t t
 //      but this is not reflected here
 // BUG: convert CUCHECK into error checks and return an error
 
-                // loop over overlapping ranges, 
-                //     maybe even on consecutive ranges when not on page boundary
-                //   unregister range
-                //   merge with union range
-                // register union range
+// loop over overlapping ranges, 
+//     maybe even on consecutive ranges when not on page boundary
+//   unregister range
+//   merge with union range
+// register union range
 
 //-----------------------------------------------------------------------------
 
@@ -95,31 +95,31 @@ int gds_map_mem(void *ptr, size_t size, gds_memory_type_t mem_type, CUdeviceptr 
 
         range_set::find_result res = rset.find(r);
         switch(res.second) {
-        case range_set::not_found:
-                return gds_register_mem_internal(ptr, size, mem_type, dev_ptr);
-                break;
-        case range_set::partial_overlap:
-                gds_err("partial overlap, buffer already registered?\n");
-                return EINVAL;
-        case range_set::fully_contained: {
-                range r = *res.first;
-                if (dev_ptr) {
-                        pindown_cache_t::iterator found = pinned_ranges.find(r.first);
-                        if (found != pinned_ranges.end()) {
-                                CUdeviceptr page_dev_ptr = (*found).second;
-                                ptrdiff_t off = (ptrdiff_t)ptr - (ptrdiff_t)r.first;
-                                *dev_ptr = page_dev_ptr + off;
+                case range_set::not_found:
+                        return gds_register_mem_internal(ptr, size, mem_type, dev_ptr);
+                        break;
+                case range_set::partial_overlap:
+                        gds_err("partial overlap, buffer already registered?\n");
+                        return EINVAL;
+                case range_set::fully_contained: {
+                        range r = *res.first;
+                        if (dev_ptr) {
+                                pindown_cache_t::iterator found = pinned_ranges.find(r.first);
+                                if (found != pinned_ranges.end()) {
+                                        CUdeviceptr page_dev_ptr = (*found).second;
+                                        ptrdiff_t off = (ptrdiff_t)ptr - (ptrdiff_t)r.first;
+                                        *dev_ptr = page_dev_ptr + off;
+                                }
+                                else {
+                                        gds_err("can't find dev_ptr for page_addr=%lx\n", r.first);
+                                        return EINVAL;
+                                }
                         }
-                        else {
-                                gds_err("can't find dev_ptr for page_addr=%lx\n", r.first);
-                                return EINVAL;
-                        }
+                        break;
                 }
-                break;
-        }
-        default:
-                gds_err("unexpected result");
-                return EINVAL;
+                default:
+                        gds_err("unexpected result");
+                        return EINVAL;
         }
 
         return 0;
@@ -149,24 +149,24 @@ int gds_register_mem_internal(void *ptr, size_t size, gds_memory_type_t type, CU
         unsigned long target_page_size = 0;
 
         switch (type) {
-        case GDS_MEMORY_GPU:
-                gds_dbg("this is GPU memory, no CUDA registration required\n");
-                need_cuda_registration = false;
-                target_page_mask = GDS_GPU_PAGE_MASK;
-                target_page_off = GDS_GPU_PAGE_OFF;
-                target_page_size = GDS_GPU_PAGE_SIZE;
-                break;
-        case GDS_MEMORY_IO:
-                flags |= CU_MEMHOSTREGISTER_IOMEMORY;
-                // fall through
-        case GDS_MEMORY_HOST:
-                target_page_mask = GDS_HOST_PAGE_MASK;
-                target_page_off = GDS_HOST_PAGE_OFF;
-                target_page_size = GDS_HOST_PAGE_SIZE;
-                break;
-        default:
-                gds_err("invalid mem type %d\n", type);
-                return EINVAL;
+                case GDS_MEMORY_GPU:
+                        gds_dbg("this is GPU memory, no CUDA registration required\n");
+                        need_cuda_registration = false;
+                        target_page_mask = GDS_GPU_PAGE_MASK;
+                        target_page_off = GDS_GPU_PAGE_OFF;
+                        target_page_size = GDS_GPU_PAGE_SIZE;
+                        break;
+                case GDS_MEMORY_IO:
+                        flags |= CU_MEMHOSTREGISTER_IOMEMORY;
+                        // fall through
+                case GDS_MEMORY_HOST:
+                        target_page_mask = GDS_HOST_PAGE_MASK;
+                        target_page_off = GDS_HOST_PAGE_OFF;
+                        target_page_size = GDS_HOST_PAGE_SIZE;
+                        break;
+                default:
+                        gds_err("invalid mem type %d\n", type);
+                        return EINVAL;
         }
 
         unsigned long page_addr = addr & target_page_mask;
@@ -180,7 +180,7 @@ int gds_register_mem_internal(void *ptr, size_t size, gds_memory_type_t type, CU
                         // we are good here
                 }
                 else if ((res == CUDA_ERROR_HOST_MEMORY_ALREADY_REGISTERED) ||
-                         (res == CUDA_ERROR_ALREADY_MAPPED)) {
+                                (res == CUDA_ERROR_ALREADY_MAPPED)) {
                         const char *err_str = NULL;
                         cuGetErrorString(res, &err_str);
                         // older CUDA driver versions seem to return CUDA_ERROR_ALREADY_MAPPED 
@@ -196,7 +196,7 @@ int gds_register_mem_internal(void *ptr, size_t size, gds_memory_type_t type, CU
                         const char *err_str = NULL;
                         cuGetErrorString(res, &err_str);
                         gds_err("Error %d (%s) while register address=%p size=%zu (original size %zu) flags=%08x\n", 
-                                res, err_str, (void*)page_addr, len, size, flags);
+                                        res, err_str, (void*)page_addr, len, size, flags);
                         // TODO: handle ENOPERM
                         return EINVAL;
                 }
@@ -260,74 +260,74 @@ int gds_mem_devptr(void *va, size_t n_bytes, CUdeviceptr *pdev_ptr)
 #if 0
 
 #if 0
-        char *ptr = (char*)_ptr;
-        char *p = ptr;
-        bool new_reg = false;
-	bool first_page = true;
+char *ptr = (char*)_ptr;
+char *p = ptr;
+bool new_reg = false;
+bool first_page = true;
 
-        if (!size) {
-                gds_err("invalid 0 size buffer\n");
-                return EINVAL;
-        }
+if (!size) {
+        gds_err("invalid 0 size buffer\n");
+        return EINVAL;
+}
 
-        while (size) {
-                unsigned long addr = (unsigned long)p;
-                unsigned long page_addr = addr & GDS_HOST_PAGE_MASK;
-                unsigned long off = addr & GDS_HOST_PAGE_OFF;
-                unsigned long len = min((GDS_HOST_PAGE_SIZE - off), (unsigned long long)size);
-		CUdeviceptr page_dev_ptr = 0;
-                //gds_dbg("page_addr=%lx len=%lu\n", page_addr, len);
-                if (last_pinned.page_addr == page_addr) {
-                        gds_dbg("hit last_pinned cache\n");
-                        page_dev_ptr = last_pinned.dev_addr;
+while (size) {
+        unsigned long addr = (unsigned long)p;
+        unsigned long page_addr = addr & GDS_HOST_PAGE_MASK;
+        unsigned long off = addr & GDS_HOST_PAGE_OFF;
+        unsigned long len = min((GDS_HOST_PAGE_SIZE - off), (unsigned long long)size);
+        CUdeviceptr page_dev_ptr = 0;
+        //gds_dbg("page_addr=%lx len=%lu\n", page_addr, len);
+        if (last_pinned.page_addr == page_addr) {
+                gds_dbg("hit last_pinned cache\n");
+                page_dev_ptr = last_pinned.dev_addr;
+        } else {
+                //gds_dbg("traversing map\n");
+                pindown_cache_t::iterator found = pinned_pages.find(page_addr);
+                if (found != pinned_pages.end()) {
+                        page_dev_ptr = found->second;
                 } else {
-                        //gds_dbg("traversing map\n");
-                        pindown_cache_t::iterator found = pinned_pages.find(page_addr);
-                        if (found != pinned_pages.end()) {
-                                page_dev_ptr = found->second;
+                        unsigned int flags = CU_MEMHOSTREGISTER_DEVICEMAP | CU_MEMHOSTREGISTER_PORTABLE;
+                        if (is_iomem)
+                                flags |= CU_MEMHOSTREGISTER_IOMEMORY;
+                        gds_dbg("registering page_addr=%lx iomem=%d\n", page_addr, is_iomem);
+                        CUresult res = cuMemHostRegister((void*)page_addr, GDS_HOST_PAGE_SIZE, flags);
+                        if (res == CUDA_SUCCESS) {
+                        } else if ((res == CUDA_ERROR_HOST_MEMORY_ALREADY_REGISTERED) ||
+                                        (res == CUDA_ERROR_ALREADY_MAPPED)) {
+                                gds_warn("page=%p size=%llu is already registered with CUDA\n", (void*)page_addr, GDS_HOST_PAGE_SIZE);
                         } else {
-                                unsigned int flags = CU_MEMHOSTREGISTER_DEVICEMAP | CU_MEMHOSTREGISTER_PORTABLE;
-                                if (is_iomem)
-                                        flags |= CU_MEMHOSTREGISTER_IOMEMORY;
-                                gds_dbg("registering page_addr=%lx iomem=%d\n", page_addr, is_iomem);
-                                CUresult res = cuMemHostRegister((void*)page_addr, GDS_HOST_PAGE_SIZE, flags);
-                                if (res == CUDA_SUCCESS) {
-                                } else if ((res == CUDA_ERROR_HOST_MEMORY_ALREADY_REGISTERED) ||
-                                           (res == CUDA_ERROR_ALREADY_MAPPED)) {
-                                        gds_warn("page=%p size=%llu is already registered with CUDA\n", (void*)page_addr, GDS_HOST_PAGE_SIZE);
-                                } else {
-                                        //CUCHECK(res);
-                                        const char *err_str = NULL;
-                                        cuGetErrorString(res, &err_str);
-                                        gds_err("Error '%s' while register address=%p size=%llu flags=%08x\n", 
+                                //CUCHECK(res);
+                                const char *err_str = NULL;
+                                cuGetErrorString(res, &err_str);
+                                gds_err("Error '%s' while register address=%p size=%llu flags=%08x\n", 
                                                 err_str, (void*)page_addr, GDS_HOST_PAGE_SIZE, flags);
-                                        // TODO: handle ENOPERM
-                                        return EINVAL;
-                                }
-                                CUCHECK(cuMemHostGetDevicePointer(&page_dev_ptr, (void *)page_addr, 0));
-                                gds_dbg("page_ptr=%lx page_dev_ptr=%lx\n", page_addr, (unsigned long)page_dev_ptr);
-                                pinned_pages[page_addr] = page_dev_ptr;
-                                new_reg = true;
+                                // TODO: handle ENOPERM
+                                return EINVAL;
                         }
-                        last_pinned.page_addr = page_addr;
-                        last_pinned.dev_addr = page_dev_ptr;
+                        CUCHECK(cuMemHostGetDevicePointer(&page_dev_ptr, (void *)page_addr, 0));
+                        gds_dbg("page_ptr=%lx page_dev_ptr=%lx\n", page_addr, (unsigned long)page_dev_ptr);
+                        pinned_pages[page_addr] = page_dev_ptr;
+                        new_reg = true;
                 }
-		if (first_page) {
-		    first_page = 0;
-		    *dev_ptr = (CUdeviceptr) (page_dev_ptr + off);
-		}
-                size -= min(len, size);
-                p += len;
+                last_pinned.page_addr = page_addr;
+                last_pinned.dev_addr = page_dev_ptr;
         }
+        if (first_page) {
+                first_page = 0;
+                *dev_ptr = (CUdeviceptr) (page_dev_ptr + off);
+        }
+        size -= min(len, size);
+        p += len;
+}
 #if 0
-        // consistency check
-        {
-                CUdeviceptr my_dev_ptr;
-                CUCHECK(cuMemHostGetDevicePointer(&my_dev_ptr, _ptr, 0));
-                assert(my_dev_ptr == *dev_ptr);
-        }
+// consistency check
+{
+        CUdeviceptr my_dev_ptr;
+        CUCHECK(cuMemHostGetDevicePointer(&my_dev_ptr, _ptr, 0));
+        assert(my_dev_ptr == *dev_ptr);
+}
 #endif
-        return 0;
+return 0;
 #endif
 
 int gds_lookup_devptr(void *va, CUdeviceptr *dev_ptr)

--- a/src/mlnxutils.h
+++ b/src/mlnxutils.h
@@ -40,29 +40,29 @@
  * which do not guarantee order of copying.
  */
 #if defined(__x86_64__)
-#define COPY_64B_NT(dst, src)		\
-	__asm__ __volatile__ (		\
-	" movdqa   (%1),%%xmm0\n"	\
-	" movdqa 16(%1),%%xmm1\n"	\
-	" movdqa 32(%1),%%xmm2\n"	\
-	" movdqa 48(%1),%%xmm3\n"	\
-	" movntdq %%xmm0,   (%0)\n"	\
-	" movntdq %%xmm1, 16(%0)\n"	\
-	" movntdq %%xmm2, 32(%0)\n"	\
-	" movntdq %%xmm3, 48(%0)\n"	\
-	: : "r" (dst), "r" (src) : "memory");	\
-	dst += 8;			\
-	src += 8
+#define COPY_64B_NT(dst, src)		        \
+        __asm__ __volatile__ (		        \
+                " movdqa   (%1),%%xmm0\n"	\
+                " movdqa 16(%1),%%xmm1\n"	\
+                " movdqa 32(%1),%%xmm2\n"	\
+                " movdqa 48(%1),%%xmm3\n"	\
+                " movntdq %%xmm0,   (%0)\n"	\
+                " movntdq %%xmm1, 16(%0)\n"	\
+                " movntdq %%xmm2, 32(%0)\n"	\
+                " movntdq %%xmm3, 48(%0)\n"	\
+                : : "r" (dst), "r" (src) : "memory");	\
+        dst += 8;			\
+        src += 8
 #else
 #define COPY_64B_NT(dst, src)	\
-	*dst++ = *src++;	\
-	*dst++ = *src++;	\
-	*dst++ = *src++;	\
-	*dst++ = *src++;	\
-	*dst++ = *src++;	\
-	*dst++ = *src++;	\
-	*dst++ = *src++;	\
-	*dst++ = *src++
+        *dst++ = *src++;	\
+        *dst++ = *src++;	\
+        *dst++ = *src++;	\
+        *dst++ = *src++;	\
+        *dst++ = *src++;	\
+        *dst++ = *src++;	\
+        *dst++ = *src++;	\
+        *dst++ = *src++
 
 #endif
 // no WQ wrap-around check!!!
@@ -70,10 +70,10 @@ static inline void gds_bf_copy(uint64_t *dest, uint64_t *src, size_t n_bytes)
 {
         assert(n_bytes % sizeof(uint64_t) == 0);
         assert(n_bytes < 128);
-	while (n_bytes > 0) {
-		COPY_64B_NT(dest, src);
-		n_bytes -= 8 * sizeof(*dest);
-	}
+        while (n_bytes > 0) {
+                COPY_64B_NT(dest, src);
+                n_bytes -= 8 * sizeof(*dest);
+        }
 }
 
 

--- a/src/mlx5.cpp
+++ b/src/mlx5.cpp
@@ -49,7 +49,7 @@
                 mlx5_i->db_value = db_val.qw;
 #endif
 
-//-----------------------------------------------------------------------------
+                //-----------------------------------------------------------------------------
 
 int gds_mlx5_get_send_descs(gds_mlx5_send_info_t *mlx5_i, const gds_send_request_s *request)
 {
@@ -62,89 +62,89 @@ int gds_mlx5_get_send_descs(gds_mlx5_send_info_t *mlx5_i, const gds_send_request
 
         for (; op && n < n_ops; op = op->next, ++n) {
                 switch(op->type) {
-                case IBV_EXP_PEER_OP_FENCE: {
-                        gds_dbg("OP_FENCE: fence_flags=%" PRIu64 "\n", op->wr.fence.fence_flags);
-                        uint32_t fence_op = (op->wr.fence.fence_flags & (IBV_EXP_PEER_FENCE_OP_READ|IBV_EXP_PEER_FENCE_OP_WRITE));
-                        uint32_t fence_from = (op->wr.fence.fence_flags & (IBV_EXP_PEER_FENCE_FROM_CPU|IBV_EXP_PEER_FENCE_FROM_HCA));
-                        uint32_t fence_mem = (op->wr.fence.fence_flags & (IBV_EXP_PEER_FENCE_MEM_SYS|IBV_EXP_PEER_FENCE_MEM_PEER));
-                        if (fence_op == IBV_EXP_PEER_FENCE_OP_READ) {
-                                gds_dbg("nothing to do for read fences\n");
+                        case IBV_EXP_PEER_OP_FENCE: {
+                                gds_dbg("OP_FENCE: fence_flags=%" PRIu64 "\n", op->wr.fence.fence_flags);
+                                uint32_t fence_op = (op->wr.fence.fence_flags & (IBV_EXP_PEER_FENCE_OP_READ|IBV_EXP_PEER_FENCE_OP_WRITE));
+                                uint32_t fence_from = (op->wr.fence.fence_flags & (IBV_EXP_PEER_FENCE_FROM_CPU|IBV_EXP_PEER_FENCE_FROM_HCA));
+                                uint32_t fence_mem = (op->wr.fence.fence_flags & (IBV_EXP_PEER_FENCE_MEM_SYS|IBV_EXP_PEER_FENCE_MEM_PEER));
+                                if (fence_op == IBV_EXP_PEER_FENCE_OP_READ) {
+                                        gds_dbg("nothing to do for read fences\n");
+                                        break;
+                                }
+                                if (fence_from != IBV_EXP_PEER_FENCE_FROM_HCA) {
+                                        gds_err("unexpected from fence\n");
+                                        retcode = EINVAL;
+                                        break;
+                                }
+                                if (fence_mem == IBV_EXP_PEER_FENCE_MEM_PEER) {
+                                        gds_dbg("using light membar\n");
+                                        mlx5_i->membar = 1;
+                                }
+                                else if (fence_mem == IBV_EXP_PEER_FENCE_MEM_SYS) {
+                                        gds_dbg("using heavy membar\n");
+                                        mlx5_i->membar_full = 1;
+                                }
+                                else {
+                                        gds_err("unsupported fence combination\n");
+                                        retcode = EINVAL;
+                                        break;
+                                }
                                 break;
                         }
-                        if (fence_from != IBV_EXP_PEER_FENCE_FROM_HCA) {
-                                gds_err("unexpected from fence\n");
+                        case IBV_EXP_PEER_OP_STORE_DWORD: {
+                                CUdeviceptr dev_ptr = range_from_id(op->wr.dword_va.target_id)->dptr + 
+                                        op->wr.dword_va.offset;
+                                uint32_t data = op->wr.dword_va.data;
+                                gds_dbg("OP_STORE_DWORD dev_ptr=%" PRIx64 " data=%08x\n", (uint64_t)dev_ptr, data);
+                                if (n != 0) {
+                                        gds_err("store DWORD is not 1st op\n");
+                                        retcode = EINVAL;
+                                        break;
+                                }
+                                mlx5_i->dbrec_ptr = (uint32_t*)dev_ptr;
+                                mlx5_i->dbrec_value = data;
+                                break;
+                        }
+                        case IBV_EXP_PEER_OP_STORE_QWORD: {
+                                CUdeviceptr dev_ptr = range_from_id(op->wr.qword_va.target_id)->dptr +
+                                        op->wr.qword_va.offset;
+                                uint64_t data = op->wr.qword_va.data;
+                                gds_dbg("OP_STORE_QWORD dev_ptr=%" PRIx64 " data=%" PRIx64 "\n", (uint64_t)dev_ptr, (uint64_t)data);
+                                if (n != 2) {
+                                        gds_err("store QWORD is not 3rd op\n");
+                                        retcode = EINVAL;
+                                        break;
+                                }
+                                mlx5_i->db_ptr = (uint64_t*)dev_ptr;
+                                mlx5_i->db_value = data;
+                                break;
+                        }
+                        case IBV_EXP_PEER_OP_COPY_BLOCK: {
+                                CUdeviceptr dev_ptr = range_from_id(op->wr.copy_op.target_id)->dptr +
+                                        op->wr.copy_op.offset;
+                                size_t len = op->wr.copy_op.len;
+                                void *src = op->wr.copy_op.src;
+                                gds_dbg("send inline detected\n");
+                                if (len < 8 || len > 64) {
+                                        gds_err("unexpected len %zu\n", len);
+                                        retcode = EINVAL;
+                                        break;
+                                }
+                                mlx5_i->db_ptr = (uint64_t*)dev_ptr;
+                                mlx5_i->db_value = *(uint64_t*)src; 
+                                break;
+                        }
+                        case IBV_EXP_PEER_OP_POLL_AND_DWORD:
+                        case IBV_EXP_PEER_OP_POLL_GEQ_DWORD:
+                        case IBV_EXP_PEER_OP_POLL_NOR_DWORD: {
+                                gds_err("unexpected polling op in send request\n");
                                 retcode = EINVAL;
                                 break;
                         }
-                        if (fence_mem == IBV_EXP_PEER_FENCE_MEM_PEER) {
-                                gds_dbg("using light membar\n");
-                                mlx5_i->membar = 1;
-                        }
-                        else if (fence_mem == IBV_EXP_PEER_FENCE_MEM_SYS) {
-                                gds_dbg("using heavy membar\n");
-                                mlx5_i->membar_full = 1;
-                        }
-                        else {
-                                gds_err("unsupported fence combination\n");
+                        default:
+                                gds_err("undefined peer op type %d\n", op->type);
                                 retcode = EINVAL;
                                 break;
-                        }
-                        break;
-                }
-                case IBV_EXP_PEER_OP_STORE_DWORD: {
-                        CUdeviceptr dev_ptr = range_from_id(op->wr.dword_va.target_id)->dptr + 
-                                op->wr.dword_va.offset;
-                        uint32_t data = op->wr.dword_va.data;
-                        gds_dbg("OP_STORE_DWORD dev_ptr=%" PRIx64 " data=%08x\n", (uint64_t)dev_ptr, data);
-                        if (n != 0) {
-                                gds_err("store DWORD is not 1st op\n");
-                                retcode = EINVAL;
-                                break;
-                        }
-                        mlx5_i->dbrec_ptr = (uint32_t*)dev_ptr;
-                        mlx5_i->dbrec_value = data;
-                        break;
-                }
-                case IBV_EXP_PEER_OP_STORE_QWORD: {
-                        CUdeviceptr dev_ptr = range_from_id(op->wr.qword_va.target_id)->dptr +
-                                op->wr.qword_va.offset;
-                        uint64_t data = op->wr.qword_va.data;
-                        gds_dbg("OP_STORE_QWORD dev_ptr=%" PRIx64 " data=%" PRIx64 "\n", (uint64_t)dev_ptr, (uint64_t)data);
-                        if (n != 2) {
-                                gds_err("store QWORD is not 3rd op\n");
-                                retcode = EINVAL;
-                                break;
-                        }
-                        mlx5_i->db_ptr = (uint64_t*)dev_ptr;
-                        mlx5_i->db_value = data;
-                        break;
-                }
-                case IBV_EXP_PEER_OP_COPY_BLOCK: {
-                        CUdeviceptr dev_ptr = range_from_id(op->wr.copy_op.target_id)->dptr +
-                                op->wr.copy_op.offset;
-                        size_t len = op->wr.copy_op.len;
-                        void *src = op->wr.copy_op.src;
-                        gds_dbg("send inline detected\n");
-                        if (len < 8 || len > 64) {
-                                gds_err("unexpected len %zu\n", len);
-                                retcode = EINVAL;
-                                break;
-                        }
-                        mlx5_i->db_ptr = (uint64_t*)dev_ptr;
-                        mlx5_i->db_value = *(uint64_t*)src; 
-                        break;
-                }
-                case IBV_EXP_PEER_OP_POLL_AND_DWORD:
-                case IBV_EXP_PEER_OP_POLL_GEQ_DWORD:
-                case IBV_EXP_PEER_OP_POLL_NOR_DWORD: {
-                        gds_err("unexpected polling op in send request\n");
-                        retcode = EINVAL;
-                        break;
-                }
-                default:
-                        gds_err("undefined peer op type %d\n", op->type);
-                        retcode = EINVAL;
-                        break;
                 }
 
                 if (retcode) {
@@ -159,21 +159,21 @@ int gds_mlx5_get_send_descs(gds_mlx5_send_info_t *mlx5_i, const gds_send_request
 
 int gds_mlx5_get_send_info(int count, const gds_send_request_t *requests, gds_mlx5_send_info_t *mlx5_infos)
 {
-    int retcode = 0;
+        int retcode = 0;
 
-    for (int j=0; j<count; j++) {
-        gds_mlx5_send_info *mlx5_i = mlx5_infos + j;
-        const gds_send_request_s *request = to_gds_send_request_s(requests + j);
-        retcode = gds_mlx5_get_send_descs(mlx5_i, request);
-        if (retcode) {
-            gds_err("error %d while retrieving descriptors for %dth request\n", retcode, j);
-            break;
+        for (int j=0; j<count; j++) {
+                gds_mlx5_send_info *mlx5_i = mlx5_infos + j;
+                const gds_send_request_s *request = to_gds_send_request_s(requests + j);
+                retcode = gds_mlx5_get_send_descs(mlx5_i, request);
+                if (retcode) {
+                        gds_err("error %d while retrieving descriptors for %dth request\n", retcode, j);
+                        break;
+                }
+                gds_dbg("mlx5_i: dbrec={%p,%08x} db={%p,%" PRIx64 "}\n",
+                                mlx5_i->dbrec_ptr, mlx5_i->dbrec_value, mlx5_i->db_ptr, mlx5_i->db_value);
         }
-        gds_dbg("mlx5_i: dbrec={%p,%08x} db={%p,%" PRIx64 "}\n",
-                mlx5_i->dbrec_ptr, mlx5_i->dbrec_value, mlx5_i->db_ptr, mlx5_i->db_value);
-    }
 
-    return retcode;
+        return retcode;
 }
 
 //-----------------------------------------------------------------------------
@@ -189,92 +189,92 @@ int gds_mlx5_get_wait_descs(gds_mlx5_wait_info_t *mlx5_i, const gds_wait_request
 
         for (; op && n < n_ops; op = op->next, ++n) {
                 switch(op->type) {
-                case IBV_EXP_PEER_OP_FENCE: {
-                        gds_dbg("OP_FENCE: fence_flags=%" PRIu64 "\n", op->wr.fence.fence_flags);
-                        uint32_t fence_op = (op->wr.fence.fence_flags & (IBV_EXP_PEER_FENCE_OP_READ|IBV_EXP_PEER_FENCE_OP_WRITE));
-                        uint32_t fence_from = (op->wr.fence.fence_flags & (IBV_EXP_PEER_FENCE_FROM_CPU|IBV_EXP_PEER_FENCE_FROM_HCA));
-                        uint32_t fence_mem = (op->wr.fence.fence_flags & (IBV_EXP_PEER_FENCE_MEM_SYS|IBV_EXP_PEER_FENCE_MEM_PEER));
-                        if (fence_op == IBV_EXP_PEER_FENCE_OP_READ) {
-                                gds_dbg("nothing to do for read fences\n");
-                                break;
-                        }
-                        if (fence_from != IBV_EXP_PEER_FENCE_FROM_HCA) {
-                                gds_err("unexpected from fence\n");
+                        case IBV_EXP_PEER_OP_FENCE: {
+                                gds_dbg("OP_FENCE: fence_flags=%" PRIu64 "\n", op->wr.fence.fence_flags);
+                                uint32_t fence_op = (op->wr.fence.fence_flags & (IBV_EXP_PEER_FENCE_OP_READ|IBV_EXP_PEER_FENCE_OP_WRITE));
+                                uint32_t fence_from = (op->wr.fence.fence_flags & (IBV_EXP_PEER_FENCE_FROM_CPU|IBV_EXP_PEER_FENCE_FROM_HCA));
+                                uint32_t fence_mem = (op->wr.fence.fence_flags & (IBV_EXP_PEER_FENCE_MEM_SYS|IBV_EXP_PEER_FENCE_MEM_PEER));
+                                if (fence_op == IBV_EXP_PEER_FENCE_OP_READ) {
+                                        gds_dbg("nothing to do for read fences\n");
+                                        break;
+                                }
+                                if (fence_from != IBV_EXP_PEER_FENCE_FROM_HCA) {
+                                        gds_err("unexpected from fence\n");
+                                        retcode = EINVAL;
+                                        break;
+                                }
+                                gds_err("unsupported fence combination\n");
                                 retcode = EINVAL;
                                 break;
                         }
-                        gds_err("unsupported fence combination\n");
-                        retcode = EINVAL;
-                        break;
-                }
-                case IBV_EXP_PEER_OP_STORE_DWORD: {
-                        CUdeviceptr dev_ptr = range_from_id(op->wr.dword_va.target_id)->dptr + 
-                                op->wr.dword_va.offset;
-                        uint32_t data = op->wr.dword_va.data;
-                        gds_dbg("OP_STORE_DWORD dev_ptr=%" PRIx64 " data=%08x\n", (uint64_t)dev_ptr, data);
-                        if (n != 1) {
-                                gds_err("store DWORD is not 2nd op\n");
+                        case IBV_EXP_PEER_OP_STORE_DWORD: {
+                                CUdeviceptr dev_ptr = range_from_id(op->wr.dword_va.target_id)->dptr + 
+                                        op->wr.dword_va.offset;
+                                uint32_t data = op->wr.dword_va.data;
+                                gds_dbg("OP_STORE_DWORD dev_ptr=%" PRIx64 " data=%08x\n", (uint64_t)dev_ptr, data);
+                                if (n != 1) {
+                                        gds_err("store DWORD is not 2nd op\n");
+                                        retcode = EINVAL;
+                                        break;
+                                }
+                                mlx5_i->flag_ptr = (uint32_t*)dev_ptr;
+                                mlx5_i->flag_value = data;
+                                break;
+                        }
+                        case IBV_EXP_PEER_OP_STORE_QWORD: {
+                                CUdeviceptr dev_ptr = range_from_id(op->wr.qword_va.target_id)->dptr +
+                                        op->wr.qword_va.offset;
+                                uint64_t data = op->wr.qword_va.data;
+                                gds_dbg("OP_STORE_QWORD dev_ptr=%" PRIx64 " data=%" PRIx64 "\n", (uint64_t)dev_ptr, (uint64_t)data);
+                                gds_err("unsupported QWORD op\n");
                                 retcode = EINVAL;
                                 break;
                         }
-                        mlx5_i->flag_ptr = (uint32_t*)dev_ptr;
-                        mlx5_i->flag_value = data;
-                        break;
-                }
-                case IBV_EXP_PEER_OP_STORE_QWORD: {
-                        CUdeviceptr dev_ptr = range_from_id(op->wr.qword_va.target_id)->dptr +
-                                op->wr.qword_va.offset;
-                        uint64_t data = op->wr.qword_va.data;
-                        gds_dbg("OP_STORE_QWORD dev_ptr=%" PRIx64 " data=%" PRIx64 "\n", (uint64_t)dev_ptr, (uint64_t)data);
-                        gds_err("unsupported QWORD op\n");
-                        retcode = EINVAL;
-                        break;
-                }
-                case IBV_EXP_PEER_OP_COPY_BLOCK: {
-                        CUdeviceptr dev_ptr = range_from_id(op->wr.copy_op.target_id)->dptr +
-                                op->wr.copy_op.offset;
-                        size_t len = op->wr.copy_op.len;
-                        void *src = op->wr.copy_op.src;
-                        gds_err("unsupported COPY_BLOCK\n");
-                        retcode = EINVAL;
-                        break;
-                }
-                case IBV_EXP_PEER_OP_POLL_AND_DWORD:
-                case IBV_EXP_PEER_OP_POLL_GEQ_DWORD:
-                case IBV_EXP_PEER_OP_POLL_NOR_DWORD: {
-                        CUdeviceptr dev_ptr = range_from_id(op->wr.dword_va.target_id)->dptr + 
-                                op->wr.dword_va.offset;
-                        uint32_t data = op->wr.dword_va.data;
-
-                        gds_dbg("OP_POLL_DWORD dev_ptr=%" PRIx64 " data=%08x\n", (uint64_t)dev_ptr, data);
-
-                        mlx5_i->cqe_ptr = (uint32_t *)dev_ptr;
-                        mlx5_i->cqe_value = data;
-
-                        switch(op->type) {
-                        case IBV_EXP_PEER_OP_POLL_NOR_DWORD:
-                                // GPU SMs can always do NOR
-                                mlx5_i->cond = GDS_WAIT_COND_NOR;
+                        case IBV_EXP_PEER_OP_COPY_BLOCK: {
+                                CUdeviceptr dev_ptr = range_from_id(op->wr.copy_op.target_id)->dptr +
+                                        op->wr.copy_op.offset;
+                                size_t len = op->wr.copy_op.len;
+                                void *src = op->wr.copy_op.src;
+                                gds_err("unsupported COPY_BLOCK\n");
+                                retcode = EINVAL;
                                 break;
-                        case IBV_EXP_PEER_OP_POLL_GEQ_DWORD:
-                                mlx5_i->cond = GDS_WAIT_COND_GEQ;
-                                break;
+                        }
                         case IBV_EXP_PEER_OP_POLL_AND_DWORD:
-                                mlx5_i->cond = GDS_WAIT_COND_AND;
+                        case IBV_EXP_PEER_OP_POLL_GEQ_DWORD:
+                        case IBV_EXP_PEER_OP_POLL_NOR_DWORD: {
+                                CUdeviceptr dev_ptr = range_from_id(op->wr.dword_va.target_id)->dptr + 
+                                        op->wr.dword_va.offset;
+                                uint32_t data = op->wr.dword_va.data;
+
+                                gds_dbg("OP_POLL_DWORD dev_ptr=%" PRIx64 " data=%08x\n", (uint64_t)dev_ptr, data);
+
+                                mlx5_i->cqe_ptr = (uint32_t *)dev_ptr;
+                                mlx5_i->cqe_value = data;
+
+                                switch(op->type) {
+                                        case IBV_EXP_PEER_OP_POLL_NOR_DWORD:
+                                                // GPU SMs can always do NOR
+                                                mlx5_i->cond = GDS_WAIT_COND_NOR;
+                                                break;
+                                        case IBV_EXP_PEER_OP_POLL_GEQ_DWORD:
+                                                mlx5_i->cond = GDS_WAIT_COND_GEQ;
+                                                break;
+                                        case IBV_EXP_PEER_OP_POLL_AND_DWORD:
+                                                mlx5_i->cond = GDS_WAIT_COND_AND;
+                                                break;
+                                        default:
+                                                gds_err("unexpected op type\n");
+                                                retcode = EINVAL;
+                                                goto err;
+                                }
                                 break;
-                        default:
-                                gds_err("unexpected op type\n");
-                                retcode = EINVAL;
-                                goto err;
                         }
-                        break;
+                        default:
+                                gds_err("undefined peer op type %d\n", op->type);
+                                retcode = EINVAL;
+                                break;
                 }
-                default:
-                        gds_err("undefined peer op type %d\n", op->type);
-                        retcode = EINVAL;
-                        break;
-                }
-        err:
+err:
                 if (retcode) {
                         gds_err("error in fill func at entry n=%zu\n", n);
                         break;
@@ -287,21 +287,21 @@ int gds_mlx5_get_wait_descs(gds_mlx5_wait_info_t *mlx5_i, const gds_wait_request
 
 int gds_mlx5_get_wait_info(int count, const gds_wait_request_t *requests, gds_mlx5_wait_info_t *mlx5_infos)
 {
-    int retcode = 0;
+        int retcode = 0;
 
-    for (int j=0; j<count; j++) {
-        gds_mlx5_wait_info *mlx5_i = mlx5_infos + j;
-        const gds_wait_request_s *request = to_gds_wait_request_s(requests + j);
-        retcode = gds_mlx5_get_wait_descs(mlx5_i, request);
-        if (retcode) {
-            gds_err("error %d while retrieving descriptors for %dth request\n", retcode, j);
-            break;
+        for (int j=0; j<count; j++) {
+                gds_mlx5_wait_info *mlx5_i = mlx5_infos + j;
+                const gds_wait_request_s *request = to_gds_wait_request_s(requests + j);
+                retcode = gds_mlx5_get_wait_descs(mlx5_i, request);
+                if (retcode) {
+                        gds_err("error %d while retrieving descriptors for %dth request\n", retcode, j);
+                        break;
+                }
+                gds_dbg("wait[%d] cqe_ptr=%p cqe_value=0x%08x flag_ptr=%p flag_value=0x%08x\n", 
+                                j, mlx5_i->cqe_ptr, mlx5_i->cqe_value, mlx5_i->flag_ptr, mlx5_i->flag_value);
         }
-        gds_dbg("wait[%d] cqe_ptr=%p cqe_value=0x%08x flag_ptr=%p flag_value=0x%08x\n", 
-                j, mlx5_i->cqe_ptr, mlx5_i->cqe_value, mlx5_i->flag_ptr, mlx5_i->flag_value);
-    }
 
-    return retcode;
+        return retcode;
 }
 
 //-----------------------------------------------------------------------------

--- a/src/mlx5.cpp
+++ b/src/mlx5.cpp
@@ -51,7 +51,7 @@
 
 //-----------------------------------------------------------------------------
 
-int gds_mlx5_get_send_descs(gds_mlx5_send_info_t *mlx5_i, const gds_send_request_t *request)
+int gds_mlx5_get_send_descs(gds_mlx5_send_info_t *mlx5_i, const gds_send_request_s *request)
 {
         int retcode = 0;
         size_t n_ops = request->commit.entries;
@@ -159,26 +159,26 @@ int gds_mlx5_get_send_descs(gds_mlx5_send_info_t *mlx5_i, const gds_send_request
 
 int gds_mlx5_get_send_info(int count, const gds_send_request_t *requests, gds_mlx5_send_info_t *mlx5_infos)
 {
-        int retcode = 0;
+    int retcode = 0;
 
-	for (int j=0; j<count; j++) {
-                gds_mlx5_send_info *mlx5_i = mlx5_infos + j;
-                const gds_send_request_t *request = requests + j;
-                retcode = gds_mlx5_get_send_descs(mlx5_i, request);
-                if (retcode) {
-                        gds_err("error %d while retrieving descriptors for %dth request\n", retcode, j);
-                        break;
-                }
-                gds_dbg("mlx5_i: dbrec={%p,%08x} db={%p,%" PRIx64 "}\n",
-                        mlx5_i->dbrec_ptr, mlx5_i->dbrec_value, mlx5_i->db_ptr, mlx5_i->db_value);
-	}
+    for (int j=0; j<count; j++) {
+        gds_mlx5_send_info *mlx5_i = mlx5_infos + j;
+        const gds_send_request_s *request = to_gds_send_request_s(requests + j);
+        retcode = gds_mlx5_get_send_descs(mlx5_i, request);
+        if (retcode) {
+            gds_err("error %d while retrieving descriptors for %dth request\n", retcode, j);
+            break;
+        }
+        gds_dbg("mlx5_i: dbrec={%p,%08x} db={%p,%" PRIx64 "}\n",
+                mlx5_i->dbrec_ptr, mlx5_i->dbrec_value, mlx5_i->db_ptr, mlx5_i->db_value);
+    }
 
-	return retcode;
+    return retcode;
 }
 
 //-----------------------------------------------------------------------------
 
-int gds_mlx5_get_wait_descs(gds_mlx5_wait_info_t *mlx5_i, const gds_wait_request_t *request)
+int gds_mlx5_get_wait_descs(gds_mlx5_wait_info_t *mlx5_i, const gds_wait_request_s *request)
 {
         int retcode = 0;
         size_t n_ops = request->peek.entries;
@@ -287,21 +287,21 @@ int gds_mlx5_get_wait_descs(gds_mlx5_wait_info_t *mlx5_i, const gds_wait_request
 
 int gds_mlx5_get_wait_info(int count, const gds_wait_request_t *requests, gds_mlx5_wait_info_t *mlx5_infos)
 {
-        int retcode = 0;
+    int retcode = 0;
 
-	for (int j=0; j<count; j++) {
-                gds_mlx5_wait_info *mlx5_i = mlx5_infos + j;
-                const gds_wait_request_t *request = requests + j;
-                retcode = gds_mlx5_get_wait_descs(mlx5_i, request);
-                if (retcode) {
-                        gds_err("error %d while retrieving descriptors for %dth request\n", retcode, j);
-                        break;
-                }
-                gds_dbg("wait[%d] cqe_ptr=%p cqe_value=0x%08x flag_ptr=%p flag_value=0x%08x\n", 
-                        j, mlx5_i->cqe_ptr, mlx5_i->cqe_value, mlx5_i->flag_ptr, mlx5_i->flag_value);
+    for (int j=0; j<count; j++) {
+        gds_mlx5_wait_info *mlx5_i = mlx5_infos + j;
+        const gds_wait_request_s *request = to_gds_wait_request_s(requests + j);
+        retcode = gds_mlx5_get_wait_descs(mlx5_i, request);
+        if (retcode) {
+            gds_err("error %d while retrieving descriptors for %dth request\n", retcode, j);
+            break;
         }
+        gds_dbg("wait[%d] cqe_ptr=%p cqe_value=0x%08x flag_ptr=%p flag_value=0x%08x\n", 
+                j, mlx5_i->cqe_ptr, mlx5_i->cqe_value, mlx5_i->flag_ptr, mlx5_i->flag_value);
+    }
 
-        return retcode;
+    return retcode;
 }
 
 //-----------------------------------------------------------------------------

--- a/src/objs.cpp
+++ b/src/objs.cpp
@@ -71,28 +71,28 @@ gds_buf *gds_peer::buf_alloc_cq(size_t length, uint32_t dir, uint32_t alignment,
 {
         gds_buf *buf = NULL;
         switch (dir) {
-        case (IBV_EXP_PEER_DIRECTION_FROM_HCA|IBV_EXP_PEER_DIRECTION_TO_PEER|IBV_EXP_PEER_DIRECTION_TO_CPU):
-                // CQ buf
-                if (GDS_ALLOC_CQ_ON_GPU == (flags & GDS_ALLOC_CQ_MASK)) {
-                        gds_dbg("allocating CQ on GPU mem\n");
-                        buf = alloc(length, alignment);
-                } else {
-                        gds_dbg("allocating CQ on Host mem\n");
-                }
-                break;
-        case (IBV_EXP_PEER_DIRECTION_FROM_PEER|IBV_EXP_PEER_DIRECTION_TO_CPU):
-                // CQ peer buf, helper buffer
-                // on SYSMEM for the near future
-                // GPU does a store to the 'busy' field as part of the peek_cq task
-                // CPU polls on that field
-                gds_dbg("allocating CQ peer buf on Host mem\n");
-                break;
-        case (IBV_EXP_PEER_DIRECTION_FROM_PEER|IBV_EXP_PEER_DIRECTION_TO_HCA):
-                gds_dbg("allocating CQ dbrec on Host mem\n");
-                break;
-        default:
-                gds_err("unexpected dir 0x%x\n", dir);
-                break;
+                case (IBV_EXP_PEER_DIRECTION_FROM_HCA|IBV_EXP_PEER_DIRECTION_TO_PEER|IBV_EXP_PEER_DIRECTION_TO_CPU):
+                        // CQ buf
+                        if (GDS_ALLOC_CQ_ON_GPU == (flags & GDS_ALLOC_CQ_MASK)) {
+                                gds_dbg("allocating CQ on GPU mem\n");
+                                buf = alloc(length, alignment);
+                        } else {
+                                gds_dbg("allocating CQ on Host mem\n");
+                        }
+                        break;
+                case (IBV_EXP_PEER_DIRECTION_FROM_PEER|IBV_EXP_PEER_DIRECTION_TO_CPU):
+                        // CQ peer buf, helper buffer
+                        // on SYSMEM for the near future
+                        // GPU does a store to the 'busy' field as part of the peek_cq task
+                        // CPU polls on that field
+                        gds_dbg("allocating CQ peer buf on Host mem\n");
+                        break;
+                case (IBV_EXP_PEER_DIRECTION_FROM_PEER|IBV_EXP_PEER_DIRECTION_TO_HCA):
+                        gds_dbg("allocating CQ dbrec on Host mem\n");
+                        break;
+                default:
+                        gds_err("unexpected dir 0x%x\n", dir);
+                        break;
         }
         return buf;
 }
@@ -101,18 +101,18 @@ gds_buf *gds_peer::buf_alloc_wq(size_t length, uint32_t dir, uint32_t alignment,
 {
         gds_buf *buf = NULL;
         switch (dir) {
-        case IBV_EXP_PEER_DIRECTION_FROM_PEER|IBV_EXP_PEER_DIRECTION_TO_HCA:
-                // dbrec
-                if (GDS_ALLOC_DBREC_ON_GPU == (flags & GDS_ALLOC_DBREC_MASK)) {
-                        gds_dbg("allocating DBREC on GPU mem\n");
-                        buf = alloc(length, alignment);
-                } else {
-                        gds_dbg("allocating DBREC on Host mem\n");
-                }
-                break;
-        default:
-                gds_err("unexpected dir=%08x\n", dir);
-                break;
+                case IBV_EXP_PEER_DIRECTION_FROM_PEER|IBV_EXP_PEER_DIRECTION_TO_HCA:
+                        // dbrec
+                        if (GDS_ALLOC_DBREC_ON_GPU == (flags & GDS_ALLOC_DBREC_MASK)) {
+                                gds_dbg("allocating DBREC on GPU mem\n");
+                                buf = alloc(length, alignment);
+                        } else {
+                                gds_dbg("allocating DBREC on Host mem\n");
+                        }
+                        break;
+                default:
+                        gds_err("unexpected dir=%08x\n", dir);
+                        break;
         }
         return buf;
 }
@@ -122,15 +122,15 @@ gds_buf *gds_peer::buf_alloc(obj_type type, size_t length, uint32_t dir, uint32_
         gds_buf *buf = NULL;
         gds_dbg("type=%d dir=%08x flags=%08x\n", type, dir, flags);
         switch (type) {
-        case CQ:
-                buf = buf_alloc_cq(length, dir, alignment, flags);
-                break;
-        case WQ:
-                buf = buf_alloc_wq(length, dir, alignment, flags);
-                break;
-        default:
-                gds_err("unexpected obj type=%d\n", type);
-                break;
+                case CQ:
+                        buf = buf_alloc_cq(length, dir, alignment, flags);
+                        break;
+                case WQ:
+                        buf = buf_alloc_wq(length, dir, alignment, flags);
+                        break;
+                default:
+                        gds_err("unexpected obj type=%d\n", type);
+                        break;
         }
 
         return buf;
@@ -151,7 +151,7 @@ gds_range *gds_peer::range_from_buf(gds_buf *buf, void *start, size_t length)
         gds_range *range = new gds_range;
         gds_dbg("buf=%p\n", buf);
         assert((ptrdiff_t)start >= (ptrdiff_t)buf->addr && 
-               (ptrdiff_t)start + length <= (ptrdiff_t)buf->addr + buf->length);
+                        (ptrdiff_t)start + length <= (ptrdiff_t)buf->addr + buf->length);
         range->va = start; // CPU mapping
         range->dptr = buf->peer_addr + ((ptrdiff_t)start - (ptrdiff_t)buf->addr);
         range->size = length;

--- a/src/objs.hpp
+++ b/src/objs.hpp
@@ -130,14 +130,20 @@ enum {
     GDS_WAIT_INFO_MAX_OPS = 32
 };
 
+enum gds_flag_internal {
+    GDS_FLAG_INTERNAL_KEEP_REQUESTS = 0x10
+};
+
 typedef struct gds_send_request {
     struct ibv_exp_peer_commit commit;
     struct peer_op_wr wr[GDS_SEND_INFO_MAX_OPS];
+    int flags;
 } gds_send_request_s;
 
 typedef struct gds_wait_request {
     struct ibv_exp_peer_peek peek;
     struct peer_op_wr wr[GDS_WAIT_INFO_MAX_OPS];
+    int flags;
 } gds_wait_request_s;
 
 static inline gds_send_request_s *to_gds_send_request_s(gds_send_request_t *request)
@@ -171,10 +177,6 @@ static inline const gds_wait_request_s *to_gds_wait_request_s(const gds_wait_req
 
     return (gds_wait_request_s *)request->handle;
 }
-
-enum gds_flag_internal {
-    GDS_FLAG_INTERNAL_KEEP_REQUESTS = 0x10
-};
 
 /*
  * Local variables:

--- a/src/objs.hpp
+++ b/src/objs.hpp
@@ -117,6 +117,11 @@ static inline gds_peer *peer_from_id(uint64_t id)
         return reinterpret_cast<gds_peer *>(id);
 }
 
+typedef struct {
+    struct gds_qp               gqp;
+    struct ibv_exp_res_domain  *res_domain;
+} gds_qp_internal_t;
+
 /*
  * Local variables:
  *  c-indent-level: 8

--- a/src/objs.hpp
+++ b/src/objs.hpp
@@ -27,6 +27,9 @@
 
 #pragma once
 
+#include <infiniband/verbs_exp.h>
+#include <infiniband/peer_ops.h>
+
 static const size_t max_gpus = 16;
 
 typedef struct ibv_exp_peer_direct_attr gds_peer_attr;
@@ -121,6 +124,21 @@ typedef struct {
     struct gds_qp               gqp;
     struct ibv_exp_res_domain  *res_domain;
 } gds_qp_internal_t;
+
+enum {
+    GDS_SEND_INFO_MAX_OPS = 32,
+    GDS_WAIT_INFO_MAX_OPS = 32
+};
+
+struct gds_send_request {
+    struct ibv_exp_peer_commit commit;
+    struct peer_op_wr wr[GDS_SEND_INFO_MAX_OPS];
+};
+
+struct gds_wait_request {
+    struct ibv_exp_peer_peek peek;
+    struct peer_op_wr wr[GDS_WAIT_INFO_MAX_OPS];
+};
 
 /*
  * Local variables:

--- a/src/objs.hpp
+++ b/src/objs.hpp
@@ -130,14 +130,50 @@ enum {
     GDS_WAIT_INFO_MAX_OPS = 32
 };
 
-struct gds_send_request {
+typedef struct gds_send_request {
     struct ibv_exp_peer_commit commit;
     struct peer_op_wr wr[GDS_SEND_INFO_MAX_OPS];
-};
+} gds_send_request_s;
 
-struct gds_wait_request {
+typedef struct gds_wait_request {
     struct ibv_exp_peer_peek peek;
     struct peer_op_wr wr[GDS_WAIT_INFO_MAX_OPS];
+} gds_wait_request_s;
+
+static inline gds_send_request_s *to_gds_send_request_s(gds_send_request_t *request)
+{
+    assert(request);
+    assert(request->handle);
+
+    return (gds_send_request_s *)request->handle;
+}
+
+static inline const gds_send_request_s *to_gds_send_request_s(const gds_send_request_t *request)
+{
+    assert(request);
+    assert(request->handle);
+
+    return (gds_send_request_s *)request->handle;
+}
+
+static inline gds_wait_request_s *to_gds_wait_request_s(gds_wait_request_t *request)
+{
+    assert(request);
+    assert(request->handle);
+
+    return (gds_wait_request_s *)request->handle;
+}
+
+static inline const gds_wait_request_s *to_gds_wait_request_s(const gds_wait_request_t *request)
+{
+    assert(request);
+    assert(request->handle);
+
+    return (gds_wait_request_s *)request->handle;
+}
+
+enum gds_flag_internal {
+    GDS_FLAG_INTERNAL_KEEP_REQUESTS = 0x10
 };
 
 /*

--- a/src/objs.hpp
+++ b/src/objs.hpp
@@ -121,61 +121,61 @@ static inline gds_peer *peer_from_id(uint64_t id)
 }
 
 typedef struct {
-    gds_qp_t                   gqp;
-    struct ibv_exp_res_domain  *res_domain;
+        gds_qp_t                   gqp;
+        struct ibv_exp_res_domain  *res_domain;
 } gds_qp_internal_t;
 
 enum {
-    GDS_SEND_INFO_MAX_OPS = 32,
-    GDS_WAIT_INFO_MAX_OPS = 32
+        GDS_SEND_INFO_MAX_OPS = 32,
+        GDS_WAIT_INFO_MAX_OPS = 32
 };
 
 enum gds_flag_internal {
-    GDS_FLAG_INTERNAL_KEEP_REQUESTS = 0x10
+        GDS_FLAG_INTERNAL_KEEP_REQUESTS = 0x10
 };
 
 typedef struct gds_send_request {
-    struct ibv_exp_peer_commit commit;
-    struct peer_op_wr wr[GDS_SEND_INFO_MAX_OPS];
-    int flags;
+        struct ibv_exp_peer_commit commit;
+        struct peer_op_wr wr[GDS_SEND_INFO_MAX_OPS];
+        int flags;
 } gds_send_request_s;
 
 typedef struct gds_wait_request {
-    struct ibv_exp_peer_peek peek;
-    struct peer_op_wr wr[GDS_WAIT_INFO_MAX_OPS];
-    int flags;
+        struct ibv_exp_peer_peek peek;
+        struct peer_op_wr wr[GDS_WAIT_INFO_MAX_OPS];
+        int flags;
 } gds_wait_request_s;
 
 static inline gds_send_request_s *to_gds_send_request_s(gds_send_request_t *request)
 {
-    assert(request);
-    assert(request->handle);
+        assert(request);
+        assert(request->handle);
 
-    return (gds_send_request_s *)request->handle;
+        return (gds_send_request_s *)request->handle;
 }
 
 static inline const gds_send_request_s *to_gds_send_request_s(const gds_send_request_t *request)
 {
-    assert(request);
-    assert(request->handle);
+        assert(request);
+        assert(request->handle);
 
-    return (gds_send_request_s *)request->handle;
+        return (gds_send_request_s *)request->handle;
 }
 
 static inline gds_wait_request_s *to_gds_wait_request_s(gds_wait_request_t *request)
 {
-    assert(request);
-    assert(request->handle);
+        assert(request);
+        assert(request->handle);
 
-    return (gds_wait_request_s *)request->handle;
+        return (gds_wait_request_s *)request->handle;
 }
 
 static inline const gds_wait_request_s *to_gds_wait_request_s(const gds_wait_request_t *request)
 {
-    assert(request);
-    assert(request->handle);
+        assert(request);
+        assert(request->handle);
 
-    return (gds_wait_request_s *)request->handle;
+        return (gds_wait_request_s *)request->handle;
 }
 
 /*

--- a/src/objs.hpp
+++ b/src/objs.hpp
@@ -121,7 +121,7 @@ static inline gds_peer *peer_from_id(uint64_t id)
 }
 
 typedef struct {
-    struct gds_qp               gqp;
+    gds_qp_t                   gqp;
     struct ibv_exp_res_domain  *res_domain;
 } gds_qp_internal_t;
 

--- a/src/task_queue.hpp
+++ b/src/task_queue.hpp
@@ -41,94 +41,94 @@
 
 // single threaded task queue
 struct task_queue {
-    task_queue() {
-        TQDBG("CTOR");
-        m_state = idle;
-    }
-
-    ~task_queue() {
-        TQDBG("DTOR");
-        kill_worker();
-    }
-
-    typedef std::function<bool()> task_t;
-    typedef std::list<task_t> task_list_t;
-    typedef task_list_t::iterator task_handle_t;
-
-    template <typename Task>
-    task_handle_t queue(Task t) {
-        lock_t lock(m_mtx);
-        task_handle_t handle = m_tasks.insert(m_tasks.end(), t);
-        if (m_state == idle) {
-            m_worker = std::thread(std::bind(&task_queue::worker_thread, this));
-            while (m_state == idle) {
-                m_cond.wait(lock);
-            }
+        task_queue() {
+                TQDBG("CTOR");
+                m_state = idle;
         }
-        m_cond.notify_one();
-        return handle;
-    }
 
-    // WARNING: dequeuing can race with self-dequeing task
-    void dequeue(task_handle_t handle) {
-        TQDBG("dequing task");
-        std::lock_guard<std::mutex> g(m_mtx);
-        m_tasks.erase(handle);
-    }
-
-private:
-    void kill_worker() {
-        TQDBG("killing worker thread");
-        {
-            lock_t g(m_mtx);
-            if (m_state == running) {
-                TQDBG("setting queue state to draining");
-                m_state = draining;
-                m_cond.notify_one();
-            }
+        ~task_queue() {
+                TQDBG("DTOR");
+                kill_worker();
         }
-        TQDBG("joining worker thread");
-        m_worker.join();
-    }
 
-    void worker_thread() {
-        lock_t lock(m_mtx);
-        TQDBG("state<-running");
-        m_state = running;
-        m_cond.notify_all();
-        while(true) {
-            if (m_state == draining) {
-                TQDBG("state<-done");
-                m_state = done;
-                break;
-            }
-            if (m_tasks.empty())
-                m_cond.wait(lock);
-            auto f = m_tasks.begin();
-            while (f != m_tasks.end()) {
-                auto fnext = std::next(f);
-                task_t t = *f;
-                lock.unlock();
-                bool keep = t();
-                lock.lock();
-                if (!keep) {
-                    TQDBG("removing task");
-                    m_tasks.erase(f);
-                    TQDBG("done");
+        typedef std::function<bool()> task_t;
+        typedef std::list<task_t> task_list_t;
+        typedef task_list_t::iterator task_handle_t;
+
+        template <typename Task>
+        task_handle_t queue(Task t) {
+                lock_t lock(m_mtx);
+                task_handle_t handle = m_tasks.insert(m_tasks.end(), t);
+                if (m_state == idle) {
+                        m_worker = std::thread(std::bind(&task_queue::worker_thread, this));
+                        while (m_state == idle) {
+                                m_cond.wait(lock);
+                        }
                 }
-                f = fnext;
-            }
+                m_cond.notify_one();
+                return handle;
         }
-    }
 
-    enum { idle, running, draining, done } m_state;
+        // WARNING: dequeuing can race with self-dequeing task
+        void dequeue(task_handle_t handle) {
+                TQDBG("dequing task");
+                std::lock_guard<std::mutex> g(m_mtx);
+                m_tasks.erase(handle);
+        }
 
-    // single threaded queue
-    std::thread m_worker;
-    std::mutex m_mtx;
-    typedef std::unique_lock<std::mutex> lock_t;
-    task_list_t m_tasks;
-    std::condition_variable m_cond;
+        private:
+        void kill_worker() {
+                TQDBG("killing worker thread");
+                {
+                        lock_t g(m_mtx);
+                        if (m_state == running) {
+                                TQDBG("setting queue state to draining");
+                                m_state = draining;
+                                m_cond.notify_one();
+                        }
+                }
+                TQDBG("joining worker thread");
+                m_worker.join();
+        }
+
+        void worker_thread() {
+                lock_t lock(m_mtx);
+                TQDBG("state<-running");
+                m_state = running;
+                m_cond.notify_all();
+                while(true) {
+                        if (m_state == draining) {
+                                TQDBG("state<-done");
+                                m_state = done;
+                                break;
+                        }
+                        if (m_tasks.empty())
+                                m_cond.wait(lock);
+                        auto f = m_tasks.begin();
+                        while (f != m_tasks.end()) {
+                                auto fnext = std::next(f);
+                                task_t t = *f;
+                                lock.unlock();
+                                bool keep = t();
+                                lock.lock();
+                                if (!keep) {
+                                        TQDBG("removing task");
+                                        m_tasks.erase(f);
+                                        TQDBG("done");
+                                }
+                                f = fnext;
+                        }
+                }
+        }
+
+        enum { idle, running, draining, done } m_state;
+
+        // single threaded queue
+        std::thread m_worker;
+        std::mutex m_mtx;
+        typedef std::unique_lock<std::mutex> lock_t;
+        task_list_t m_tasks;
+        std::condition_variable m_cond;
 };
 
 #undef TQDBG

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -41,9 +41,9 @@ void gds_assert(const char *cond, const char *file, unsigned line, const char *f
 #define GDS_ASSERT2(COND)                                               \
         do {                                                            \
                 if (!(COND))                                            \
-                        gds_assert(#COND, __FILE__, __LINE__, __FUNCTION__); \
+                gds_assert(#COND, __FILE__, __LINE__, __FUNCTION__);    \
         }                                                               \
-        while(0)
+while(0)
 
 #define GDS_ASSERT(COND) GDS_ASSERT2(COND)
 
@@ -51,15 +51,15 @@ void gds_assert(const char *cond, const char *file, unsigned line, const char *f
 // CUDA error checking
 
 #define __CUCHECK(stmt, cond_str)					\
-	do {								\
-		CUresult result = (stmt);				\
-		if (CUDA_SUCCESS != result) {				\
-			const char *err_str = NULL;			\
-			cuGetErrorString(result, &err_str);		\
-			fprintf(stderr, "Assertion \"%s != cudaSuccess\" failed at %s:%d error=%d(%s)\n", \
-                                cond_str, __FILE__, __LINE__, result, err_str); \
-			exit(EXIT_FAILURE);                             \
-		}							\
+        do {								\
+                CUresult result = (stmt);				\
+                if (CUDA_SUCCESS != result) {				\
+                        const char *err_str = NULL;			\
+                        cuGetErrorString(result, &err_str);		\
+                        fprintf(stderr, "Assertion \"%s != cudaSuccess\" failed at %s:%d error=%d(%s)\n", \
+                                        cond_str, __FILE__, __LINE__, result, err_str); \
+                        exit(EXIT_FAILURE);                             \
+                }							\
         } while (0)
 
 #define CUCHECK(stmt) __CUCHECK(stmt, #stmt)
@@ -96,10 +96,10 @@ static inline T gds_atomic_get(T *ptr)
 // tracing support
 
 enum gds_msg_level {
-    GDS_MSG_DEBUG = 1,
-    GDS_MSG_INFO,
-    GDS_MSG_WARN,
-    GDS_MSG_ERROR
+        GDS_MSG_DEBUG = 1,
+        GDS_MSG_INFO,
+        GDS_MSG_WARN,
+        GDS_MSG_ERROR
 };
 
 #define gds_stream stderr
@@ -107,9 +107,9 @@ enum gds_msg_level {
 
 int gds_dbg_enabled();
 #define gds_msg(LVL, LVLSTR, FMT, ARGS...)   do {			\
-		fprintf(gds_stream, "[%d] GDS " LVLSTR " %s() " FMT, getpid(), __FUNCTION__ ,##ARGS); \
-		fflush(gds_stream);                                     \
-	} while(0)
+        fprintf(gds_stream, "[%d] GDS " LVLSTR " %s() " FMT, getpid(), __FUNCTION__ ,##ARGS); \
+        fflush(gds_stream);                                     \
+} while(0)
 
 #define gds_dbg(FMT, ARGS...)  do { if (gds_dbg_enabled()) gds_msg(GDS_MSG_DEBUG, "DBG  ", FMT, ## ARGS); } while(0)
 #define gds_dbgc(CNT, FMT, ARGS...) do { static int __cnt = 0; if (__cnt++ < CNT) gds_dbg(FMT, ## ARGS); } while(0)
@@ -130,12 +130,12 @@ static inline int gds_curesult_to_errno(CUresult result)
 {
         int retcode = 0;
         switch (result) {
-        case CUDA_SUCCESS:             retcode = 0; break;
-        case CUDA_ERROR_NOT_SUPPORTED: retcode = EPERM; break;
-        case CUDA_ERROR_INVALID_VALUE: retcode = EINVAL; break;
-        case CUDA_ERROR_OUT_OF_MEMORY: retcode = ENOMEM; break;
-        // TODO: add missing cases
-        default: retcode = EIO; break;
+                case CUDA_SUCCESS:             retcode = 0; break;
+                case CUDA_ERROR_NOT_SUPPORTED: retcode = EPERM; break;
+                case CUDA_ERROR_INVALID_VALUE: retcode = EINVAL; break;
+                case CUDA_ERROR_OUT_OF_MEMORY: retcode = ENOMEM; break;
+                                               // TODO: add missing cases
+                default: retcode = EIO; break;
         }
         return retcode;
 }

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -195,7 +195,7 @@ typedef enum gds_alloc_qp_flags {
 
 typedef std::vector<CUstreamBatchMemOpParams> gds_op_list_t;
 
-struct gds_cq *gds_create_cq(struct ibv_context *context, int cqe, void *cq_context, struct ibv_comp_channel *channel, int comp_vector, int gpu_id, gds_alloc_cq_flags_t flags);
+gds_cq_t *gds_create_cq(struct ibv_context *context, int cqe, void *cq_context, struct ibv_comp_channel *channel, int comp_vector, int gpu_id, gds_alloc_cq_flags_t flags);
 int gds_post_pokes(CUstream stream, int count, gds_send_request_t *info, uint32_t *dw, uint32_t val);
 int gds_post_pokes_on_cpu(int count, gds_send_request_s *info, uint32_t *dw, uint32_t val);
 int gds_stream_post_wait_cq_multi(CUstream stream, int count, gds_wait_request_s *request, uint32_t *dw, uint32_t val);

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -32,6 +32,8 @@
 #endif
 #include <inttypes.h> // to pull PRIx64
 
+#include "objs.hpp"
+
 // internal assert function
 
 void gds_assert(const char *cond, const char *file, unsigned line, const char *function);
@@ -195,7 +197,8 @@ typedef std::vector<CUstreamBatchMemOpParams> gds_op_list_t;
 
 struct gds_cq *gds_create_cq(struct ibv_context *context, int cqe, void *cq_context, struct ibv_comp_channel *channel, int comp_vector, int gpu_id, gds_alloc_cq_flags_t flags);
 int gds_post_pokes(CUstream stream, int count, gds_send_request_t *info, uint32_t *dw, uint32_t val);
-int gds_post_pokes_on_cpu(int count, gds_send_request_t *info, uint32_t *dw, uint32_t val);
+int gds_post_pokes_on_cpu(int count, gds_send_request_s *info, uint32_t *dw, uint32_t val);
+int gds_stream_post_wait_cq_multi(CUstream stream, int count, gds_wait_request_s *request, uint32_t *dw, uint32_t val);
 int gds_stream_post_wait_cq_multi(CUstream stream, int count, gds_wait_request_t *request, uint32_t *dw, uint32_t val);
 void gds_dump_wait_request(gds_wait_request_t *request, size_t count);
 void gds_dump_param(CUstreamBatchMemOpParams *param);

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -198,7 +198,6 @@ typedef std::vector<CUstreamBatchMemOpParams> gds_op_list_t;
 gds_cq_t *gds_create_cq(struct ibv_context *context, int cqe, void *cq_context, struct ibv_comp_channel *channel, int comp_vector, int gpu_id, gds_alloc_cq_flags_t flags);
 int gds_post_pokes(CUstream stream, int count, gds_send_request_t *info, uint32_t *dw, uint32_t val);
 int gds_post_pokes_on_cpu(int count, gds_send_request_s *info, uint32_t *dw, uint32_t val);
-int gds_stream_post_wait_cq_multi(CUstream stream, int count, gds_wait_request_s *request, uint32_t *dw, uint32_t val);
 int gds_stream_post_wait_cq_multi(CUstream stream, int count, gds_wait_request_t *request, uint32_t *dw, uint32_t val);
 void gds_dump_wait_request(gds_wait_request_t *request, size_t count);
 void gds_dump_param(CUstreamBatchMemOpParams *param);

--- a/tests/gds_kernel_latency.c
+++ b/tests/gds_kernel_latency.c
@@ -124,7 +124,7 @@ struct pingpong_context {
 	struct ibv_cq		*tx_cq;
 	struct ibv_cq		*rx_cq;
 	struct ibv_qp		*qp;
-	struct gds_qp		*gds_qp;
+	gds_qp_t		    *gds_qp;
 	struct ibv_ah		*ah;
 	void			*buf;
 	char			*txbuf;

--- a/tests/gds_kernel_latency.c
+++ b/tests/gds_kernel_latency.c
@@ -68,18 +68,18 @@
 
 #include <mpi.h>
 
-#define MPI_CHECK(stmt)                                             \
-do {                                                                \
-    int result = (stmt);                                            \
-    if (MPI_SUCCESS != result) {                                    \
-        char string[MPI_MAX_ERROR_STRING];                          \
-        int resultlen = 0;                                          \
-        MPI_Error_string(result, string, &resultlen);               \
-        fprintf(stderr, " (%s:%d) MPI check failed with %d (%*s)\n", \
-                __FILE__, __LINE__, result, resultlen, string);      \
-        exit(EXIT_FAILURE);                                          \
-    }                                                               \
-} while(0)
+#define MPI_CHECK(stmt)                                                                 \
+        do {                                                                            \
+                int result = (stmt);                                                    \
+                if (MPI_SUCCESS != result) {                                            \
+                        char string[MPI_MAX_ERROR_STRING];                              \
+                        int resultlen = 0;                                              \
+                        MPI_Error_string(result, string, &resultlen);                   \
+                        fprintf(stderr, " (%s:%d) MPI check failed with %d (%*s)\n",    \
+                                        __FILE__, __LINE__, result, resultlen, string); \
+                        exit(EXIT_FAILURE);                                             \
+                }                                                                       \
+        } while(0)
 
 
 //-----------------------------------------------------------------------------
@@ -101,8 +101,8 @@ int prof_idx = 0;
 #define USE_CUDA_PROFILER 1
 
 enum {
-	PINGPONG_RECV_WRID = 1,
-	PINGPONG_SEND_WRID = 2,
+        PINGPONG_RECV_WRID = 1,
+        PINGPONG_SEND_WRID = 2,
 };
 
 static int page_size;
@@ -117,28 +117,28 @@ int max_batch_len = 20;
 int stream_cb_error = 0;
 
 struct pingpong_context {
-	struct ibv_context	*context;
-	struct ibv_comp_channel *channel;
-	struct ibv_pd		*pd;
-	struct ibv_mr		*mr;
-	struct ibv_cq		*tx_cq;
-	struct ibv_cq		*rx_cq;
-	struct ibv_qp		*qp;
-    gds_qp_t            *gds_qp;
-	struct ibv_ah		*ah;
-	void			*buf;
-	char			*txbuf;
+        struct ibv_context	*context;
+        struct ibv_comp_channel *channel;
+        struct ibv_pd		*pd;
+        struct ibv_mr		*mr;
+        struct ibv_cq		*tx_cq;
+        struct ibv_cq		*rx_cq;
+        struct ibv_qp		*qp;
+        gds_qp_t                *gds_qp;
+        struct ibv_ah		*ah;
+        void			*buf;
+        char			*txbuf;
         char                    *rxbuf;
         char                    *rx_flag;
-	int			 size;
+        int			 size;
         int                      calc_size;
-	int			 rx_depth;
-	int			 pending;
-	struct ibv_port_attr     portinfo;
-	int                      gpu_id;
-	int                      kernel_duration;
-	int                      peersync;
-	int                      peersync_gpu_cq;
+        int			 rx_depth;
+        int			 pending;
+        struct ibv_port_attr     portinfo;
+        int                      gpu_id;
+        int                      kernel_duration;
+        int                      peersync;
+        int                      peersync_gpu_cq;
         int                      consume_rx_cqe;
         int                      gpumem;
         int                      use_desc_apis;
@@ -152,62 +152,62 @@ struct pingpong_context {
 static int my_rank, comm_size;
 
 struct pingpong_dest {
-	int lid;
-	int qpn;
-	int psn;
-	union ibv_gid gid;
+        int lid;
+        int qpn;
+        int psn;
+        union ibv_gid gid;
 };
 
 static inline unsigned long align_to(unsigned long val, unsigned long pow2)
 {
-	return (val + pow2 - 1) & ~(pow2 - 1);
+        return (val + pow2 - 1) & ~(pow2 - 1);
 }
 
 
 static struct pingpong_context *pp_init_ctx(struct ibv_device *ib_dev, int size, int calc_size,
-					    int rx_depth, int port,
-					    int use_event,
-					    int gpu_id,
-                                            int peersync,
-                                            int peersync_gpu_cq,
-                                            int peersync_gpu_dbrec,
-                                            int consume_rx_cqe,
-                                            int sched_mode,
-                                            int use_gpumem,
-                                            int use_desc_apis,
-                                            int skip_kernel_launch)
+        int rx_depth, int port,
+        int use_event,
+        int gpu_id,
+        int peersync,
+        int peersync_gpu_cq,
+        int peersync_gpu_dbrec,
+        int consume_rx_cqe,
+        int sched_mode,
+        int use_gpumem,
+        int use_desc_apis,
+        int skip_kernel_launch)
 {
-	struct pingpong_context *ctx;
+        struct pingpong_context *ctx;
 
-	if (gpu_id >=0 && gpu_init(gpu_id, sched_mode)) {
-		fprintf(stderr, "error in GPU init.\n");
-		return NULL;
-	}
+        if (gpu_id >=0 && gpu_init(gpu_id, sched_mode)) {
+                fprintf(stderr, "error in GPU init.\n");
+                return NULL;
+        }
 
-	ctx = malloc(sizeof *ctx);
-	if (!ctx)
-		return NULL;
+        ctx = malloc(sizeof *ctx);
+        if (!ctx)
+                return NULL;
 
-	ctx->size     = size;
-	ctx->calc_size = calc_size;
-	ctx->rx_depth = rx_depth;
-	ctx->gpu_id   = gpu_id;
+        ctx->size     = size;
+        ctx->calc_size = calc_size;
+        ctx->rx_depth = rx_depth;
+        ctx->gpu_id   = gpu_id;
         ctx->gpumem   = use_gpumem;
         ctx->use_desc_apis = use_desc_apis;
         ctx->skip_kernel_launch = skip_kernel_launch;
 
         size_t alloc_size = 3 * align_to(size + 40, page_size);
-	if (ctx->gpumem) {
-		ctx->buf = gpu_malloc(page_size, alloc_size);
+        if (ctx->gpumem) {
+                ctx->buf = gpu_malloc(page_size, alloc_size);
                 printf("allocated GPU memory at %p\n", ctx->buf);
-	} else {
-		ctx->buf = memalign(page_size, alloc_size);
+        } else {
+                ctx->buf = memalign(page_size, alloc_size);
                 printf("allocated CPU memory at %p\n", ctx->buf);
         }
-	if (!ctx->buf) {
-		fprintf(stderr, "Couldn't allocate work buf.\n");
-		goto clean_ctx;
-	}
+        if (!ctx->buf) {
+                fprintf(stderr, "Couldn't allocate work buf.\n");
+                goto clean_ctx;
+        }
 
         gpu_info("allocated ctx buffer %p\n", ctx->buf);
         ctx->rxbuf = (char*)ctx->buf;
@@ -220,16 +220,16 @@ static struct pingpong_context *pp_init_ctx(struct ibv_device *ib_dev, int size,
                 goto clean_ctx;
         }
 
-	ctx->kernel_duration = 0;
-	ctx->peersync = peersync;
+        ctx->kernel_duration = 0;
+        ctx->peersync = peersync;
         ctx->peersync_gpu_cq = peersync_gpu_cq;
         ctx->consume_rx_cqe = consume_rx_cqe;
 
         // must be ZERO!!! for rx_flag to work...
-	if (ctx->gpumem)
-		gpu_memset(ctx->buf, 0, alloc_size);
-	else
-		memset(ctx->buf, 0, alloc_size);
+        if (ctx->gpumem)
+                gpu_memset(ctx->buf, 0, alloc_size);
+        else
+                memset(ctx->buf, 0, alloc_size);
 
         memset(ctx->rx_flag, 0, alloc_size);
         gpu_register_host_mem(ctx->rx_flag, alloc_size);
@@ -240,33 +240,33 @@ static struct pingpong_context *pp_init_ctx(struct ibv_device *ib_dev, int size,
         gpu_launch_kernel(ctx->calc_size, ctx->peersync);
         CUCHECK(cuCtxSynchronize());
 
-	ctx->context = ibv_open_device(ib_dev);
-	if (!ctx->context) {
-		gpu_err("Couldn't get context for %s\n",
-			ibv_get_device_name(ib_dev));
-		goto clean_buffer;
-	}
+        ctx->context = ibv_open_device(ib_dev);
+        if (!ctx->context) {
+                gpu_err("Couldn't get context for %s\n",
+                                ibv_get_device_name(ib_dev));
+                goto clean_buffer;
+        }
 
-	if (use_event) {
-		ctx->channel = ibv_create_comp_channel(ctx->context);
-		if (!ctx->channel) {
-			gpu_err("Couldn't create completion channel\n");
-			goto clean_device;
-		}
-	} else
-		ctx->channel = NULL;
+        if (use_event) {
+                ctx->channel = ibv_create_comp_channel(ctx->context);
+                if (!ctx->channel) {
+                        gpu_err("Couldn't create completion channel\n");
+                        goto clean_device;
+                }
+        } else
+                ctx->channel = NULL;
 
-	ctx->pd = ibv_alloc_pd(ctx->context);
-	if (!ctx->pd) {
-		gpu_err("Couldn't allocate PD\n");
-		goto clean_comp_channel;
-	}
+        ctx->pd = ibv_alloc_pd(ctx->context);
+        if (!ctx->pd) {
+                gpu_err("Couldn't allocate PD\n");
+                goto clean_comp_channel;
+        }
 
-	ctx->mr = ibv_reg_mr(ctx->pd, ctx->buf, alloc_size, IBV_ACCESS_LOCAL_WRITE);
-	if (!ctx->mr) {
-		gpu_err("Couldn't register MR\n");
-		goto clean_pd;
-	}
+        ctx->mr = ibv_reg_mr(ctx->pd, ctx->buf, alloc_size, IBV_ACCESS_LOCAL_WRITE);
+        if (!ctx->mr) {
+                gpu_err("Couldn't register MR\n");
+                goto clean_pd;
+        }
 
         int gds_flags = 0;
         if (peersync_gpu_cq)
@@ -291,103 +291,103 @@ static struct pingpong_context *pp_init_ctx(struct ibv_device *ib_dev, int size,
         if (!ctx->gds_qp)  {
                 gpu_err("Couldn't create QP\n");
                 goto clean_mr;
-	}
+        }
         ctx->qp = ctx->gds_qp->qp;
         ctx->tx_cq = ctx->gds_qp->qp->send_cq;
         ctx->rx_cq = ctx->gds_qp->qp->recv_cq;
 
-	{
-		struct ibv_qp_attr attr = {
-			.qp_state        = IBV_QPS_INIT,
-			.pkey_index      = 0,
-			.port_num        = port,
-			.qkey            = 0x11111111,
-			.qp_access_flags = IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ | IBV_ACCESS_LOCAL_WRITE
-		};
+        {
+                struct ibv_qp_attr attr = {
+                        .qp_state        = IBV_QPS_INIT,
+                        .pkey_index      = 0,
+                        .port_num        = port,
+                        .qkey            = 0x11111111,
+                        .qp_access_flags = IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ | IBV_ACCESS_LOCAL_WRITE
+                };
 
-		if (ibv_modify_qp(ctx->qp, &attr,
-				  IBV_QP_STATE              |
-				  IBV_QP_PKEY_INDEX         |
-				  IBV_QP_PORT               |
-				  ((IBV_QPT_UD == gds_qpt) ? IBV_QP_QKEY : IBV_QP_ACCESS_FLAGS))) {
-			gpu_err("Failed to modify QP to INIT\n");
-			goto clean_qp;
-		}
-	}
+                if (ibv_modify_qp(ctx->qp, &attr,
+                                        IBV_QP_STATE              |
+                                        IBV_QP_PKEY_INDEX         |
+                                        IBV_QP_PORT               |
+                                        ((IBV_QPT_UD == gds_qpt) ? IBV_QP_QKEY : IBV_QP_ACCESS_FLAGS))) {
+                        gpu_err("Failed to modify QP to INIT\n");
+                        goto clean_qp;
+                }
+        }
 
-	return ctx;
+        return ctx;
 
 clean_qp:
-	gds_destroy_qp(ctx->gds_qp);
+        gds_destroy_qp(ctx->gds_qp);
 
 clean_mr:
-	ibv_dereg_mr(ctx->mr);
+        ibv_dereg_mr(ctx->mr);
 
 clean_pd:
-	ibv_dealloc_pd(ctx->pd);
+        ibv_dealloc_pd(ctx->pd);
 
 clean_comp_channel:
-	if (ctx->channel)
-		ibv_destroy_comp_channel(ctx->channel);
+        if (ctx->channel)
+                ibv_destroy_comp_channel(ctx->channel);
 
 clean_device:
-	ibv_close_device(ctx->context);
+        ibv_close_device(ctx->context);
 
 clean_buffer:
-	if (ctx->gpumem)
-		gpu_free(ctx->buf); 
-	else 
-		free(ctx->buf);
+        if (ctx->gpumem)
+                gpu_free(ctx->buf); 
+        else 
+                free(ctx->buf);
 
 clean_ctx:
-	if (ctx->gpu_id >= 0)
-		gpu_finalize();
-	free(ctx);
+        if (ctx->gpu_id >= 0)
+                gpu_finalize();
+        free(ctx);
 
-	return NULL;
+        return NULL;
 }
 
 int pp_close_ctx(struct pingpong_context *ctx)
 {
-	if (gds_destroy_qp(ctx->gds_qp)) {
-		gpu_err("Couldn't destroy QP\n");
-	}
+        if (gds_destroy_qp(ctx->gds_qp)) {
+                gpu_err("Couldn't destroy QP\n");
+        }
 
-	if (ibv_dereg_mr(ctx->mr)) {
-		gpu_err("Couldn't deregister MR\n");
-	}
+        if (ibv_dereg_mr(ctx->mr)) {
+                gpu_err("Couldn't deregister MR\n");
+        }
 
-	if (IBV_QPT_UD == gds_qpt) {
-		if (ibv_destroy_ah(ctx->ah)) {
-			gpu_err("Couldn't destroy AH\n");
-		}
-	}
+        if (IBV_QPT_UD == gds_qpt) {
+                if (ibv_destroy_ah(ctx->ah)) {
+                        gpu_err("Couldn't destroy AH\n");
+                }
+        }
 
-	if (ibv_dealloc_pd(ctx->pd)) {
-		gpu_err("Couldn't deallocate PD\n");
-	}
+        if (ibv_dealloc_pd(ctx->pd)) {
+                gpu_err("Couldn't deallocate PD\n");
+        }
 
-	if (ctx->channel) {
-		if (ibv_destroy_comp_channel(ctx->channel)) {
-			gpu_err("Couldn't destroy completion channel\n");
-		}
-	}
+        if (ctx->channel) {
+                if (ibv_destroy_comp_channel(ctx->channel)) {
+                        gpu_err("Couldn't destroy completion channel\n");
+                }
+        }
 
-	if (ibv_close_device(ctx->context)) {
-		gpu_err("Couldn't release context\n");
-	}
+        if (ibv_close_device(ctx->context)) {
+                gpu_err("Couldn't release context\n");
+        }
 
-	if (ctx->gpumem)
-		gpu_free(ctx->buf); 
-	else 
-		free(ctx->buf);
+        if (ctx->gpumem)
+                gpu_free(ctx->buf); 
+        else 
+                free(ctx->buf);
 
-	if (ctx->gpu_id >= 0)
-		gpu_finalize();
+        if (ctx->gpu_id >= 0)
+                gpu_finalize();
 
-	free(ctx);
+        free(ctx);
 
-	return 0;
+        return 0;
 }
 
 static int poll_send_cq(struct pingpong_context *ctx)
@@ -408,20 +408,20 @@ static int poll_send_cq(struct pingpong_context *ctx)
         for (i = 0; i < ne; ++i) {
                 if (wc[i].status != IBV_WC_SUCCESS) {
                         gpu_err("Failed status %s (%d) for wr_id %d\n",
-                                ibv_wc_status_str(wc[i].status),
-                                wc[i].status, (int) wc[i].wr_id);
+                                        ibv_wc_status_str(wc[i].status),
+                                        wc[i].status, (int) wc[i].wr_id);
                         return 1;
                 }
 
                 switch ((int) wc[i].wr_id) {
-                case PINGPONG_SEND_WRID:
-                        ++ctx->scnt;
-                        gpu_dbg("got send event scnt=%d\n", ctx->scnt);
-                        break;
-                default:
-                        gpu_err("Completion for unknown wr_id %d\n",
-                                (int) wc[i].wr_id);
-                        return 1;
+                        case PINGPONG_SEND_WRID:
+                                ++ctx->scnt;
+                                gpu_dbg("got send event scnt=%d\n", ctx->scnt);
+                                break;
+                        default:
+                                gpu_err("Completion for unknown wr_id %d\n",
+                                                (int) wc[i].wr_id);
+                                return 1;
                 }
         }
 
@@ -448,20 +448,20 @@ static int poll_recv_cq(struct pingpong_context *ctx)
         for (i = 0; i < ne; ++i) {
                 if (wc[i].status != IBV_WC_SUCCESS) {
                         gpu_err("[%d] Failed status %s (%d) for wr_id %d\n",
-                                my_rank, ibv_wc_status_str(wc[i].status),
-                                wc[i].status, (int) wc[i].wr_id);
+                                        my_rank, ibv_wc_status_str(wc[i].status),
+                                        wc[i].status, (int) wc[i].wr_id);
                         return 1;
                 }
 
                 switch ((int) wc[i].wr_id) {
-                case PINGPONG_RECV_WRID:
-                        ++ctx->rcnt;
-                        gpu_dbg("[%d] got recv event rcnt=%d\n", my_rank, ctx->rcnt);
-                        break;
-                default:
-                        gpu_err("[%d] Completion for unknown wr_id %d\n",
-                                my_rank, (int) wc[i].wr_id);
-                        return 1;
+                        case PINGPONG_RECV_WRID:
+                                ++ctx->rcnt;
+                                gpu_dbg("[%d] got recv event rcnt=%d\n", my_rank, ctx->rcnt);
+                                break;
+                        default:
+                                gpu_err("[%d] Completion for unknown wr_id %d\n",
+                                                my_rank, (int) wc[i].wr_id);
+                                return 1;
                 }
         }
         return 0;
@@ -469,27 +469,27 @@ static int poll_recv_cq(struct pingpong_context *ctx)
 
 static int pp_post_recv(struct pingpong_context *ctx, int n)
 {
-	struct ibv_sge list = {
-		.addr	= (uintptr_t) ctx->rxbuf,
-		.length = ctx->size + 40, // good for IBV_QPT_UD
-		.lkey	= ctx->mr->lkey
-	};
+        struct ibv_sge list = {
+                .addr	= (uintptr_t) ctx->rxbuf,
+                .length = ctx->size + 40, // good for IBV_QPT_UD
+                .lkey	= ctx->mr->lkey
+        };
 
-	if (IBV_QPT_UD != gds_qpt) list.length = ctx->size;
-	
-	struct ibv_recv_wr wr = {
-		.wr_id	    = PINGPONG_RECV_WRID,
-		.sg_list    = &list,
-		.num_sge    = 1,
-	};
-	struct ibv_recv_wr *bad_wr;
-	int i;
+        if (IBV_QPT_UD != gds_qpt) list.length = ctx->size;
 
-	for (i = 0; i < n; ++i)
-		if (ibv_post_recv(ctx->qp, &wr, &bad_wr))
-			break;
+        struct ibv_recv_wr wr = {
+                .wr_id	    = PINGPONG_RECV_WRID,
+                .sg_list    = &list,
+                .num_sge    = 1,
+        };
+        struct ibv_recv_wr *bad_wr;
+        int i;
 
-	return i;
+        for (i = 0; i < n; ++i)
+                if (ibv_post_recv(ctx->qp, &wr, &bad_wr))
+                        break;
+
+        return i;
 }
 
 #if 0
@@ -506,7 +506,7 @@ static int pp_wait_cq(struct pingpong_context *ctx, int is_client)
                                         return ret;
                                 }
                         } while(ctx->n_tx_ev <= 0);
-                        
+
                         do {
                                 ret = poll_recv_cq(ctx);
                                 if (ret) {
@@ -535,72 +535,72 @@ static int pp_wait_cq(struct pingpong_context *ctx, int is_client)
 
 static int pp_post_gpu_send(struct pingpong_context *ctx, uint32_t qpn, CUstream *p_gpu_stream)
 {
-	struct ibv_sge list = {
-		.addr	= (uintptr_t) ctx->txbuf,
-		.length = ctx->size,
-		.lkey	= ctx->mr->lkey
-	};
-	gds_send_wr ewr = {
-		.wr_id	    = PINGPONG_SEND_WRID,
-		.sg_list    = &list,
-		.num_sge    = 1,
-		.opcode = IBV_WR_SEND,
-		.send_flags = IBV_SEND_SIGNALED,
-		.wr         = {
-			.ud = {
-				 .ah          = ctx->ah,
-				 .remote_qpn  = qpn,
-				 .remote_qkey = 0x11111111
-			 }
-		},
-	};
+        struct ibv_sge list = {
+                .addr	= (uintptr_t) ctx->txbuf,
+                .length = ctx->size,
+                .lkey	= ctx->mr->lkey
+        };
+        gds_send_wr ewr = {
+                .wr_id	    = PINGPONG_SEND_WRID,
+                .sg_list    = &list,
+                .num_sge    = 1,
+                .opcode = IBV_WR_SEND,
+                .send_flags = IBV_SEND_SIGNALED,
+                .wr         = {
+                        .ud = {
+                                .ah          = ctx->ah,
+                                .remote_qpn  = qpn,
+                                .remote_qkey = 0x11111111
+                        }
+                },
+        };
 #if 0
-	if (IBV_QPT_UD != gds_qpt) {
-		memset(&ewr, 0, sizeof(ewr));
-		ewr.num_sge = 1;
-		ewr.exp_send_flags = IBV_EXP_SEND_SIGNALED;
-		ewr.exp_opcode = IBV_EXP_WR_SEND;
-		ewr.wr_id = PINGPONG_SEND_WRID;
-		ewr.sg_list = &list;
-		ewr.next = NULL;
-	}
+        if (IBV_QPT_UD != gds_qpt) {
+                memset(&ewr, 0, sizeof(ewr));
+                ewr.num_sge = 1;
+                ewr.exp_send_flags = IBV_EXP_SEND_SIGNALED;
+                ewr.exp_opcode = IBV_EXP_WR_SEND;
+                ewr.wr_id = PINGPONG_SEND_WRID;
+                ewr.sg_list = &list;
+                ewr.next = NULL;
+        }
 #endif
-	gds_send_wr *bad_ewr;
+        gds_send_wr *bad_ewr;
         return gds_stream_queue_send(*p_gpu_stream, ctx->gds_qp, &ewr, &bad_ewr);
 }
 
 static int pp_prepare_gpu_send(struct pingpong_context *ctx, uint32_t qpn, gds_send_request_t *req)
 {
-	struct ibv_sge list = {
-		.addr	= (uintptr_t) ctx->txbuf,
-		.length = ctx->size,
-		.lkey	= ctx->mr->lkey
-	};
-	gds_send_wr ewr = {
-		.wr_id	    = PINGPONG_SEND_WRID,
-		.sg_list    = &list,
-		.num_sge    = 1,
-		.opcode = IBV_WR_SEND,
-		.send_flags = IBV_SEND_SIGNALED,
-		.wr         = {
-			.ud = {
-				 .ah          = ctx->ah,
-				 .remote_qpn  = qpn,
-				 .remote_qkey = 0x11111111
-			 }
-		},
-	};
-	
-	if (IBV_QPT_UD != gds_qpt) {
-		memset(&ewr, 0, sizeof(ewr));
-		ewr.num_sge = 1;
-		ewr.send_flags = IBV_SEND_SIGNALED;
-		ewr.opcode = IBV_WR_SEND;
-		ewr.wr_id = PINGPONG_SEND_WRID;
-		ewr.sg_list = &list;
-		ewr.next = NULL;
-	}
-	gds_send_wr *bad_ewr;
+        struct ibv_sge list = {
+                .addr	= (uintptr_t) ctx->txbuf,
+                .length = ctx->size,
+                .lkey	= ctx->mr->lkey
+        };
+        gds_send_wr ewr = {
+                .wr_id	    = PINGPONG_SEND_WRID,
+                .sg_list    = &list,
+                .num_sge    = 1,
+                .opcode = IBV_WR_SEND,
+                .send_flags = IBV_SEND_SIGNALED,
+                .wr         = {
+                        .ud = {
+                                .ah          = ctx->ah,
+                                .remote_qpn  = qpn,
+                                .remote_qkey = 0x11111111
+                        }
+                },
+        };
+
+        if (IBV_QPT_UD != gds_qpt) {
+                memset(&ewr, 0, sizeof(ewr));
+                ewr.num_sge = 1;
+                ewr.send_flags = IBV_SEND_SIGNALED;
+                ewr.opcode = IBV_WR_SEND;
+                ewr.wr_id = PINGPONG_SEND_WRID;
+                ewr.sg_list = &list;
+                ewr.next = NULL;
+        }
+        gds_send_wr *bad_ewr;
         return gds_prepare_send(ctx->gds_qp, &ewr, &bad_ewr, req);
 }
 
@@ -638,7 +638,7 @@ out:
 static int pp_post_work(struct pingpong_context *ctx, int n_posts, int rcnt, uint32_t qpn, int is_client)
 {
         int retcode = 0;
-	int i, ret = 0;
+        int i, ret = 0;
         int posted_recv = 0;
 
         //printf("post_work posting %d\n", n_posts);
@@ -649,7 +649,7 @@ static int pp_post_work(struct pingpong_context *ctx, int n_posts, int rcnt, uin
         posted_recv = pp_post_recv(ctx, n_posts);
         if (posted_recv < 0) {
                 gpu_err("can't post recv (%d) n_posts=%d is_client=%d\n", 
-                        posted_recv, n_posts, is_client);
+                                posted_recv, n_posts, is_client);
                 exit(EXIT_FAILURE);
                 return 0;
         } else if (posted_recv != n_posts) {
@@ -658,16 +658,16 @@ static int pp_post_work(struct pingpong_context *ctx, int n_posts, int rcnt, uin
                         return 0;
         }
         PROF(&prof, prof_idx++);
-	for (i = 0; i < posted_recv; ++i) {
+        for (i = 0; i < posted_recv; ++i) {
                 if (is_client) {
-			if (gds_enable_event_prof && (event_idx < MAX_EVENTS)) {
-				cudaEventRecord(start_time[event_idx], gpu_stream);
-			}
+                        if (gds_enable_event_prof && (event_idx < MAX_EVENTS)) {
+                                cudaEventRecord(start_time[event_idx], gpu_stream);
+                        }
                         if (ctx->use_desc_apis) {
                                 work_desc_t *wdesc = calloc(1, sizeof(work_desc_t));
                                 if (wdesc == NULL) {
-                                    gpu_err("[%d] cannot calloc wdesc\n", my_rank);
-                                    exit(EXIT_FAILURE);
+                                        gpu_err("[%d] cannot calloc wdesc\n", my_rank);
+                                        exit(EXIT_FAILURE);
                                 }
 
                                 int k = 0;
@@ -715,7 +715,7 @@ static int pp_post_work(struct pingpong_context *ctx, int n_posts, int rcnt, uin
                                 ret = pp_post_gpu_send(ctx, qpn, &gpu_stream);
                                 if (ret) {
                                         gpu_err("error %d in pp_post_gpu_send, posted_recv=%d posted_so_far=%d is_client=%d \n",
-                                                ret, posted_recv, i, is_client);
+                                                        ret, posted_recv, i, is_client);
                                         retcode = -ret;
                                         break;
                                 }
@@ -740,10 +740,10 @@ static int pp_post_work(struct pingpong_context *ctx, int n_posts, int rcnt, uin
                                 break;
                         }
 
-			if (gds_enable_event_prof && (event_idx < MAX_EVENTS)) {
-				cudaEventRecord(stop_time[event_idx], gpu_stream);
-				event_idx++;
-			} 
+                        if (gds_enable_event_prof && (event_idx < MAX_EVENTS)) {
+                                cudaEventRecord(stop_time[event_idx], gpu_stream);
+                                event_idx++;
+                        } 
                         if (ctx->skip_kernel_launch) {
                                 gpu_warn_once("[%d] NOT LAUNCHING ANY KERNEL AT ALL\n", my_rank);
                         } else {
@@ -755,8 +755,8 @@ static int pp_post_work(struct pingpong_context *ctx, int n_posts, int rcnt, uin
                         if (ctx->use_desc_apis) {
                                 work_desc_t *wdesc = calloc(1, sizeof(work_desc_t));
                                 if (wdesc == 0) {
-                                    gpu_err("[%d] cannot calloc wdesc\n", my_rank);
-                                    exit(EXIT_FAILURE);
+                                        gpu_err("[%d] cannot calloc wdesc\n", my_rank);
+                                        exit(EXIT_FAILURE);
                                 }
 
                                 int k = 0;
@@ -800,14 +800,14 @@ static int pp_post_work(struct pingpong_context *ctx, int n_posts, int rcnt, uin
                         } else {
                                 gpu_launch_kernel(ctx->calc_size, ctx->peersync);
                         }
-			if (gds_enable_event_prof && (event_idx < MAX_EVENTS)) {
-				cudaEventRecord(start_time[event_idx], gpu_stream);
-			} 
+                        if (gds_enable_event_prof && (event_idx < MAX_EVENTS)) {
+                                cudaEventRecord(start_time[event_idx], gpu_stream);
+                        } 
                         if (ctx->use_desc_apis) {
                                 work_desc_t *wdesc = calloc(1, sizeof(work_desc_t));
                                 if (wdesc == NULL) {
-                                    gpu_err("[%d] cannot calloc wdesc\n", my_rank);
-                                    exit(EXIT_FAILURE);
+                                        gpu_err("[%d] cannot calloc wdesc\n", my_rank);
+                                        exit(EXIT_FAILURE);
                                 }
 
                                 int k = 0;
@@ -845,7 +845,7 @@ static int pp_post_work(struct pingpong_context *ctx, int n_posts, int rcnt, uin
                                 ret = pp_post_gpu_send(ctx, qpn, &gpu_stream);
                                 if (ret) {
                                         gpu_err("error %d in pp_post_gpu_send, posted_recv=%d posted_so_far=%d is_client=%d \n",
-                                                ret, posted_recv, i, is_client);
+                                                        ret, posted_recv, i, is_client);
                                         retcode = -ret;
                                         break;
                                 }
@@ -862,10 +862,10 @@ static int pp_post_work(struct pingpong_context *ctx, int n_posts, int rcnt, uin
                                 break;
                         }
 
-			if (gds_enable_event_prof && (event_idx < MAX_EVENTS)) {
-				cudaEventRecord(stop_time[event_idx], gpu_stream);
-				event_idx++;
-			} 
+                        if (gds_enable_event_prof && (event_idx < MAX_EVENTS)) {
+                                cudaEventRecord(stop_time[event_idx], gpu_stream);
+                                event_idx++;
+                        } 
                 }
         }
         PROF(&prof, prof_idx++);
@@ -875,67 +875,67 @@ static int pp_post_work(struct pingpong_context *ctx, int n_posts, int rcnt, uin
                 //sleep(1);
         }
 
-	return retcode;
+        return retcode;
 }
 
 static void usage(const char *argv0)
 {
-	printf("Usage:\n");
-	printf("  %s            start a server and wait for connection\n", argv0);
-	printf("  %s <host>     connect to server at <host>\n", argv0);
-	printf("\n");
-	printf("Options:\n");
-	printf("  -p, --port=<port>      listen on/connect to port <port> (default 18515)\n");
-	printf("  -d, --ib-dev=<dev>     use IB device <dev> (default first device found)\n");
-	printf("  -i, --ib-port=<port>   use port <port> of IB device (default 1)\n");
-	printf("  -s, --size=<size>      size of message to exchange (default 1024)\n");
-	printf("  -r, --rx-depth=<dep>   number of receives to post at a time (default 500)\n");
-	printf("  -n, --iters=<iters>    number of exchanges (default 1000)\n");
-	printf("  -e, --events           sleep on CQ events (default poll)\n");
-	printf("  -g, --gid-idx=<gid index> local port gid index\n");
-	printf("  -S, --gpu-calc-size=<size>  size of GPU compute buffer (default 128KB)\n");
-	printf("  -G, --gpu-id           use specified GPU (default 0)\n");
-	printf("  -B, --batch-length=<n> max batch length (default 20)\n");
-	printf("  -P, --peersync            enable GPUDirect PeerSync support (default enabled)\n");
-	printf("  -C, --peersync-gpu-cq     enable GPUDirect PeerSync GPU CQ support (default disabled)\n");
-	printf("  -D, --peersync-gpu-dbrec  enable QP DBREC on GPU memory (default disabled)\n");
-	printf("  -U, --peersync-desc-apis  use batched descriptor APIs (default disabled)\n");
-	printf("  -Q, --consume-rx-cqe      enable GPU consumes RX CQE support (default disabled)\n");
-	printf("  -T, --time-gds-ops        evaluate time needed to execute gds operations using cuda events\n");
-	printf("  -k, --qp-kind             select IB transport kind used by GDS QPs. (-K 1) for UD, (-K 2) for RC\n");
-	printf("  -M, --gpu-sched-mode      set CUDA context sched mode, default (A)UTO, (S)PIN, (Y)IELD, (B)LOCKING\n");
-	printf("  -E, --gpu-mem             allocate GPU intead of CPU memory buffers\n");
-	printf("  -K, --skip-kernel-launch  no GPU kernel computations, only communications\n");
+        printf("Usage:\n");
+        printf("  %s            start a server and wait for connection\n", argv0);
+        printf("  %s <host>     connect to server at <host>\n", argv0);
+        printf("\n");
+        printf("Options:\n");
+        printf("  -p, --port=<port>      listen on/connect to port <port> (default 18515)\n");
+        printf("  -d, --ib-dev=<dev>     use IB device <dev> (default first device found)\n");
+        printf("  -i, --ib-port=<port>   use port <port> of IB device (default 1)\n");
+        printf("  -s, --size=<size>      size of message to exchange (default 1024)\n");
+        printf("  -r, --rx-depth=<dep>   number of receives to post at a time (default 500)\n");
+        printf("  -n, --iters=<iters>    number of exchanges (default 1000)\n");
+        printf("  -e, --events           sleep on CQ events (default poll)\n");
+        printf("  -g, --gid-idx=<gid index> local port gid index\n");
+        printf("  -S, --gpu-calc-size=<size>  size of GPU compute buffer (default 128KB)\n");
+        printf("  -G, --gpu-id           use specified GPU (default 0)\n");
+        printf("  -B, --batch-length=<n> max batch length (default 20)\n");
+        printf("  -P, --peersync            enable GPUDirect PeerSync support (default enabled)\n");
+        printf("  -C, --peersync-gpu-cq     enable GPUDirect PeerSync GPU CQ support (default disabled)\n");
+        printf("  -D, --peersync-gpu-dbrec  enable QP DBREC on GPU memory (default disabled)\n");
+        printf("  -U, --peersync-desc-apis  use batched descriptor APIs (default disabled)\n");
+        printf("  -Q, --consume-rx-cqe      enable GPU consumes RX CQE support (default disabled)\n");
+        printf("  -T, --time-gds-ops        evaluate time needed to execute gds operations using cuda events\n");
+        printf("  -k, --qp-kind             select IB transport kind used by GDS QPs. (-K 1) for UD, (-K 2) for RC\n");
+        printf("  -M, --gpu-sched-mode      set CUDA context sched mode, default (A)UTO, (S)PIN, (Y)IELD, (B)LOCKING\n");
+        printf("  -E, --gpu-mem             allocate GPU intead of CPU memory buffers\n");
+        printf("  -K, --skip-kernel-launch  no GPU kernel computations, only communications\n");
 }
 
 int main(int argc, char *argv[])
 {
-	struct ibv_device      **dev_list;
-	struct ibv_device	*ib_dev;
-	struct pingpong_context *ctx;
-	struct pingpong_dest     my_dest;
-	struct pingpong_dest    *rem_dest = NULL;
-	struct timeval           start, end;
-	const char              *ib_devname = NULL;
-	char                    *servername = NULL;
-	int                      port = 18515;
-	int                      ib_port = 1;
-	int                      size = 1024;
-	int                      calc_size = 128*1024;
-	int                      rx_depth = 2*512;
-	int                      iters = 1000;
-	int                      use_event = 0;
-	int                      routs;
+        struct ibv_device      **dev_list;
+        struct ibv_device	*ib_dev;
+        struct pingpong_context *ctx;
+        struct pingpong_dest     my_dest;
+        struct pingpong_dest    *rem_dest = NULL;
+        struct timeval           start, end;
+        const char              *ib_devname = NULL;
+        char                    *servername = NULL;
+        int                      port = 18515;
+        int                      ib_port = 1;
+        int                      size = 1024;
+        int                      calc_size = 128*1024;
+        int                      rx_depth = 2*512;
+        int                      iters = 1000;
+        int                      use_event = 0;
+        int                      routs;
         int                      nposted;
-	int                      sl = 0;
-	int			 gidx = -1;
-	char			 gid[INET6_ADDRSTRLEN];
-	int                      gpu_id = 0;
+        int                      sl = 0;
+        int			 gidx = -1;
+        char			 gid[INET6_ADDRSTRLEN];
+        int                      gpu_id = 0;
         int                      peersync = 1;
         int                      peersync_gpu_cq = 0;
         int                      peersync_gpu_dbrec = 0;
         int                      consume_rx_cqe = 0;
-	int                      gds_qp_type = 1;
+        int                      gds_qp_type = 1;
         int                      sched_mode = CU_CTX_SCHED_AUTO;
         int                      ret = 0;
         int                      use_gpumem = 0;
@@ -965,169 +965,169 @@ int main(int argc, char *argv[])
                 MPI_Abort(MPI_COMM_WORLD, -1);
         }
 
-	srand48(getpid() * time(NULL));
+        srand48(getpid() * time(NULL));
 
-	while (1) {
-		int c;
+        while (1) {
+                int c;
 
-		static struct option long_options[] = {
-			{ .name = "port",     .has_arg = 1, .val = 'p' },
-			{ .name = "ib-dev",   .has_arg = 1, .val = 'd' },
-			{ .name = "ib-port",  .has_arg = 1, .val = 'i' },
-			{ .name = "size",     .has_arg = 1, .val = 's' },
-			{ .name = "rx-depth", .has_arg = 1, .val = 'r' },
-			{ .name = "iters",    .has_arg = 1, .val = 'n' },
-			{ .name = "sl",       .has_arg = 1, .val = 'l' },
-			{ .name = "events",   .has_arg = 0, .val = 'e' },
-			{ .name = "gid-idx",  .has_arg = 1, .val = 'g' },
-			{ .name = "gpu-id",          .has_arg = 1, .val = 'G' },
-			{ .name = "peersync",        .has_arg = 0, .val = 'P' },
-			{ .name = "peersync-gpu-cq", .has_arg = 0, .val = 'C' },
-			{ .name = "peersync-gpu-dbrec", .has_arg = 1, .val = 'D' },
+                static struct option long_options[] = {
+                        { .name = "port",     .has_arg = 1, .val = 'p' },
+                        { .name = "ib-dev",   .has_arg = 1, .val = 'd' },
+                        { .name = "ib-port",  .has_arg = 1, .val = 'i' },
+                        { .name = "size",     .has_arg = 1, .val = 's' },
+                        { .name = "rx-depth", .has_arg = 1, .val = 'r' },
+                        { .name = "iters",    .has_arg = 1, .val = 'n' },
+                        { .name = "sl",       .has_arg = 1, .val = 'l' },
+                        { .name = "events",   .has_arg = 0, .val = 'e' },
+                        { .name = "gid-idx",  .has_arg = 1, .val = 'g' },
+                        { .name = "gpu-id",          .has_arg = 1, .val = 'G' },
+                        { .name = "peersync",        .has_arg = 0, .val = 'P' },
+                        { .name = "peersync-gpu-cq", .has_arg = 0, .val = 'C' },
+                        { .name = "peersync-gpu-dbrec", .has_arg = 1, .val = 'D' },
                         { .name = "peersync-desc-apis", .has_arg = 0, .val = 'U' },
-			{ .name = "gpu-calc-size",   .has_arg = 1, .val = 'S' },
-			{ .name = "batch-length",    .has_arg = 1, .val = 'B' },
-			{ .name = "consume-rx-cqe",  .has_arg = 0, .val = 'Q' },
-			{ .name = "time-gds-ops",  .has_arg = 0, .val = 'T' },
-			{ .name = "qp-kind",          .has_arg = 1, .val = 'k' },
-			{ .name = "gpu-sched-mode",  .has_arg = 1, .val = 'M' },
-			{ .name = "gpu-mem",         .has_arg = 0, .val = 'E' },
-			{ .name = "skip-kernel-launch", .has_arg = 0, .val = 'K' },
-			{ 0 }
-		};
+                        { .name = "gpu-calc-size",   .has_arg = 1, .val = 'S' },
+                        { .name = "batch-length",    .has_arg = 1, .val = 'B' },
+                        { .name = "consume-rx-cqe",  .has_arg = 0, .val = 'Q' },
+                        { .name = "time-gds-ops",  .has_arg = 0, .val = 'T' },
+                        { .name = "qp-kind",          .has_arg = 1, .val = 'k' },
+                        { .name = "gpu-sched-mode",  .has_arg = 1, .val = 'M' },
+                        { .name = "gpu-mem",         .has_arg = 0, .val = 'E' },
+                        { .name = "skip-kernel-launch", .has_arg = 0, .val = 'K' },
+                        { 0 }
+                };
 
-		c = getopt_long(argc, argv, "p:d:i:s:r:n:l:eg:G:k:S:B:PCDQTM:EUK", long_options, NULL);
-		if (c == -1)
-			break;
+                c = getopt_long(argc, argv, "p:d:i:s:r:n:l:eg:G:k:S:B:PCDQTM:EUK", long_options, NULL);
+                if (c == -1)
+                        break;
 
-		switch (c) {
-		case 'p':
-			port = strtol(optarg, NULL, 0);
-			if (port < 0 || port > 65535) {
-				usage(argv[0]);
-                                ret = 1;
-                                exit(EXIT_FAILURE);
-			}
-			break;
+                switch (c) {
+                        case 'p':
+                                port = strtol(optarg, NULL, 0);
+                                if (port < 0 || port > 65535) {
+                                        usage(argv[0]);
+                                        ret = 1;
+                                        exit(EXIT_FAILURE);
+                                }
+                                break;
 
-		case 'd':
-			ib_devname = strdupa(optarg);
-			break;
+                        case 'd':
+                                ib_devname = strdupa(optarg);
+                                break;
 
-		case 'i':
-			ib_port = strtol(optarg, NULL, 0);
-			if (ib_port < 0) {
-				usage(argv[0]);
-				ret = 1;
-                                exit(EXIT_FAILURE);
-			}
-			break;
+                        case 'i':
+                                ib_port = strtol(optarg, NULL, 0);
+                                if (ib_port < 0) {
+                                        usage(argv[0]);
+                                        ret = 1;
+                                        exit(EXIT_FAILURE);
+                                }
+                                break;
 
-		case 's':
-			size = strtol(optarg, NULL, 0);
-			break;
+                        case 's':
+                                size = strtol(optarg, NULL, 0);
+                                break;
 
-		case 'S':
-			calc_size = strtol(optarg, NULL, 0);
-			break;
+                        case 'S':
+                                calc_size = strtol(optarg, NULL, 0);
+                                break;
 
-		case 'r':
-			rx_depth = strtol(optarg, NULL, 0);
-			break;
+                        case 'r':
+                                rx_depth = strtol(optarg, NULL, 0);
+                                break;
 
-		case 'n':
-			iters = strtol(optarg, NULL, 0);
-			break;
+                        case 'n':
+                                iters = strtol(optarg, NULL, 0);
+                                break;
 
-		case 'l':
-			sl = strtol(optarg, NULL, 0);
-			break;
+                        case 'l':
+                                sl = strtol(optarg, NULL, 0);
+                                break;
 
-		case 'e':
-			++use_event;
-			break;
+                        case 'e':
+                                ++use_event;
+                                break;
 
-		case 'g':
-			gidx = strtol(optarg, NULL, 0);
-			break;
+                        case 'g':
+                                gidx = strtol(optarg, NULL, 0);
+                                break;
 
-		case 'G':
-			gpu_id = strtol(optarg, NULL, 0);
-                        printf("INFO: gpu id=%d\n", gpu_id);
-			break;
+                        case 'G':
+                                gpu_id = strtol(optarg, NULL, 0);
+                                printf("INFO: gpu id=%d\n", gpu_id);
+                                break;
 
-		case 'B':
-			max_batch_len = strtol(optarg, NULL, 0);
-                        printf("INFO: max_batch_len=%d\n", max_batch_len);
-			break;
+                        case 'B':
+                                max_batch_len = strtol(optarg, NULL, 0);
+                                printf("INFO: max_batch_len=%d\n", max_batch_len);
+                                break;
 
-		case 'P':
-			peersync = !peersync;
-                        printf("INFO: switching PeerSync %s\n", peersync?"ON":"OFF");
-			break;
-			
-		case 'k':
-			gds_qp_type = (int) strtol(optarg, NULL, 0);
-                        switch (gds_qp_type) {
-                        case 1: printf("INFO: GDS_QPT %s\n","UD"); gds_qpt = IBV_QPT_UD; break;
-                        case 2: printf("INFO: GDS_QPT %s\n","RC"); gds_qpt = IBV_QPT_RC; break;
-                        default: printf("ERROR: unexpected value 1 for UD or 2 for RC \n"); exit(EXIT_FAILURE); break;
-                        }
-			break;
-		case 'Q':
-			consume_rx_cqe = !consume_rx_cqe;
-                        printf("INFO: switching consume_rx_cqe %s\n", consume_rx_cqe?"ON":"OFF");
-			break;
-			
-		case 'T':
-			gds_enable_event_prof = !gds_enable_event_prof;
-                        printf("INFO: gds_enable_event_prof %s\n", gds_enable_event_prof?"ON":"OFF");
-			break;
+                        case 'P':
+                                peersync = !peersync;
+                                printf("INFO: switching PeerSync %s\n", peersync?"ON":"OFF");
+                                break;
 
-		case 'C':
-			peersync_gpu_cq = !peersync_gpu_cq;
-                        printf("INFO: switching %s PeerSync GPU CQ\n", peersync_gpu_cq?"ON":"OFF");
-			break;
+                        case 'k':
+                                gds_qp_type = (int) strtol(optarg, NULL, 0);
+                                switch (gds_qp_type) {
+                                        case 1: printf("INFO: GDS_QPT %s\n","UD"); gds_qpt = IBV_QPT_UD; break;
+                                        case 2: printf("INFO: GDS_QPT %s\n","RC"); gds_qpt = IBV_QPT_RC; break;
+                                        default: printf("ERROR: unexpected value 1 for UD or 2 for RC \n"); exit(EXIT_FAILURE); break;
+                                }
+                                break;
+                        case 'Q':
+                                consume_rx_cqe = !consume_rx_cqe;
+                                printf("INFO: switching consume_rx_cqe %s\n", consume_rx_cqe?"ON":"OFF");
+                                break;
 
-		case 'D':
-			peersync_gpu_dbrec= !peersync_gpu_dbrec;
-                        printf("INFO: switching %s PeerSync GPU QP DBREC\n", peersync_gpu_dbrec?"ON":"OFF");
-			break;
+                        case 'T':
+                                gds_enable_event_prof = !gds_enable_event_prof;
+                                printf("INFO: gds_enable_event_prof %s\n", gds_enable_event_prof?"ON":"OFF");
+                                break;
 
-		case 'M':
-                {
-                        char m = *optarg;
-                        printf("INFO: sched mode '%c'\n", m);
-                        switch (m) {
-                        case 'S': sched_mode = CU_CTX_SCHED_SPIN; break;
-                        case 'Y': sched_mode = CU_CTX_SCHED_YIELD; break;
-                        case 'B': sched_mode = CU_CTX_SCHED_BLOCKING_SYNC; break;
-                        case 'A': sched_mode = CU_CTX_SCHED_AUTO; break;
-                        default: printf("ERROR: unexpected value %c\n", m); exit(EXIT_FAILURE); break;
-                        }
+                        case 'C':
+                                peersync_gpu_cq = !peersync_gpu_cq;
+                                printf("INFO: switching %s PeerSync GPU CQ\n", peersync_gpu_cq?"ON":"OFF");
+                                break;
+
+                        case 'D':
+                                peersync_gpu_dbrec= !peersync_gpu_dbrec;
+                                printf("INFO: switching %s PeerSync GPU QP DBREC\n", peersync_gpu_dbrec?"ON":"OFF");
+                                break;
+
+                        case 'M':
+                                {
+                                        char m = *optarg;
+                                        printf("INFO: sched mode '%c'\n", m);
+                                        switch (m) {
+                                                case 'S': sched_mode = CU_CTX_SCHED_SPIN; break;
+                                                case 'Y': sched_mode = CU_CTX_SCHED_YIELD; break;
+                                                case 'B': sched_mode = CU_CTX_SCHED_BLOCKING_SYNC; break;
+                                                case 'A': sched_mode = CU_CTX_SCHED_AUTO; break;
+                                                default: printf("ERROR: unexpected value %c\n", m); exit(EXIT_FAILURE); break;
+                                        }
+                                }
+                                break;
+
+                        case 'E':
+                                use_gpumem = !use_gpumem;
+                                printf("INFO: use_gpumem=%d\n", use_gpumem);
+                                break;
+
+                        case 'U':
+                                use_desc_apis = 1;
+                                printf("INFO: use_desc_apis=%d\n", use_desc_apis);
+                                break;
+
+                        case 'K':
+                                skip_kernel_launch = 1;
+                                printf("INFO: skip_kernel_launch=%d\n", skip_kernel_launch);
+                                break;
+
+                        default:
+                                usage(argv[0]);
+                                return 1;
                 }
-                break;
-
-                case 'E':
-                        use_gpumem = !use_gpumem;
-                        printf("INFO: use_gpumem=%d\n", use_gpumem);
-                        break;
-
-                case 'U':
-                        use_desc_apis = 1;
-                        printf("INFO: use_desc_apis=%d\n", use_desc_apis);
-                        break;
-                        
-                case 'K':
-                        skip_kernel_launch = 1;
-                        printf("INFO: skip_kernel_launch=%d\n", skip_kernel_launch);
-                        break;
-
-		default:
-			usage(argv[0]);
-			return 1;
-		}
-	}
+        }
 
         if (!peersync && !use_desc_apis) {
                 gpu_err("!peersync case only supported when using descriptor APIs, enabling them\n");
@@ -1145,7 +1145,7 @@ int main(int argc, char *argv[])
                                 hostnames, MPI_MAX_PROCESSOR_NAME, MPI_CHAR, MPI_COMM_WORLD));
 
         if (my_rank == 1) {
-		servername = hostnames[0];
+                servername = hostnames[0];
                 printf("[%d] pid=%d server:%s\n", my_rank, getpid(), servername);
         } else {
                 printf("[%d] pid=%d client:%s\n", my_rank, getpid(), hostnames[1]);
@@ -1161,13 +1161,13 @@ int main(int argc, char *argv[])
         //prof_init(&prof, 100, 100, "100ns", 25*4, 2, tags);
         prof_disable(&prof);
 
-	page_size = sysconf(_SC_PAGESIZE);
+        page_size = sysconf(_SC_PAGESIZE);
 
-	dev_list = ibv_get_device_list(NULL);
-	if (!dev_list) {
-		perror("Failed to get IB devices list");
-		return 1;
-	}
+        dev_list = ibv_get_device_list(NULL);
+        if (!dev_list) {
+                perror("Failed to get IB devices list");
+                return 1;
+        }
 
         if (!ib_devname) {
                 const char *value = getenv("USE_HCA"); 
@@ -1179,31 +1179,31 @@ int main(int argc, char *argv[])
                 printf("[%d] requested IB device: <%s>\n", my_rank, ib_devname);
         }
 
-	{
-		const char *value = getenv("GDS_ENABLE_EVENT_PROF"); 
-		if (value != NULL) {
-			gds_enable_event_prof = atoi(value);
-		}
-	}
+        {
+                const char *value = getenv("GDS_ENABLE_EVENT_PROF"); 
+                if (value != NULL) {
+                        gds_enable_event_prof = atoi(value);
+                }
+        }
 
-	if (!ib_devname) {
+        if (!ib_devname) {
                 printf("[%d] picking 1st available device\n", my_rank);
-		ib_dev = *dev_list;
-		if (!ib_dev) {
-			gpu_err("[%d] No IB devices found\n", my_rank);
-			return 1;
-		}
-	} else {
-		int i;
-		for (i = 0; dev_list[i]; ++i)
-			if (!strcmp(ibv_get_device_name(dev_list[i]), ib_devname))
-				break;
-		ib_dev = dev_list[i];
-		if (!ib_dev) {
-			gpu_err("IB device %s not found\n", ib_devname);
-			return 1;
-		}
-	}
+                ib_dev = *dev_list;
+                if (!ib_dev) {
+                        gpu_err("[%d] No IB devices found\n", my_rank);
+                        return 1;
+                }
+        } else {
+                int i;
+                for (i = 0; dev_list[i]; ++i)
+                        if (!strcmp(ibv_get_device_name(dev_list[i]), ib_devname))
+                                break;
+                ib_dev = dev_list[i];
+                if (!ib_dev) {
+                        gpu_err("IB device %s not found\n", ib_devname);
+                        return 1;
+                }
+        }
 
         {
                 const char *env = getenv("USE_GPU");
@@ -1213,46 +1213,46 @@ int main(int argc, char *argv[])
                 }
         }
         printf("[%d] use gpumem: %d\n", my_rank, use_gpumem);
-	ctx = pp_init_ctx(ib_dev, size, calc_size, rx_depth, ib_port, 0, gpu_id, peersync, peersync_gpu_cq, peersync_gpu_dbrec, consume_rx_cqe, sched_mode, use_gpumem, use_desc_apis, skip_kernel_launch);
-	if (!ctx)
-		return 1;
+        ctx = pp_init_ctx(ib_dev, size, calc_size, rx_depth, ib_port, 0, gpu_id, peersync, peersync_gpu_cq, peersync_gpu_dbrec, consume_rx_cqe, sched_mode, use_gpumem, use_desc_apis, skip_kernel_launch);
+        if (!ctx)
+                return 1;
 
-	int nrecv = pp_post_recv(ctx, max_batch_len);
-	if (nrecv < max_batch_len) {
-		gpu_warn("[%d] Could not post all receive, requested %d, actually posted %d\n", my_rank, max_batch_len, nrecv);
-		return 1;
-	}
+        int nrecv = pp_post_recv(ctx, max_batch_len);
+        if (nrecv < max_batch_len) {
+                gpu_warn("[%d] Could not post all receive, requested %d, actually posted %d\n", my_rank, max_batch_len, nrecv);
+                return 1;
+        }
 
-	if (pp_get_port_info(ctx->context, ib_port, &ctx->portinfo)) {
-		gpu_err("[%d] Couldn't get port info\n", my_rank);
-		return 1;
-	}
-	my_dest.lid = ctx->portinfo.lid;
-	my_dest.qpn = ctx->qp->qp_num;
-	my_dest.psn = (IBV_QPT_UD == gds_qpt) ? (lrand48() & 0xffffff) : 0;
+        if (pp_get_port_info(ctx->context, ib_port, &ctx->portinfo)) {
+                gpu_err("[%d] Couldn't get port info\n", my_rank);
+                return 1;
+        }
+        my_dest.lid = ctx->portinfo.lid;
+        my_dest.qpn = ctx->qp->qp_num;
+        my_dest.psn = (IBV_QPT_UD == gds_qpt) ? (lrand48() & 0xffffff) : 0;
 
-	if (gidx >= 0) {
-		if (ibv_query_gid(ctx->context, ib_port, gidx, &my_dest.gid)) {
-			gpu_err("Could not get local gid for gid index "
-								"%d\n", gidx);
-			return 1;
-		}
-	} else
-		memset(&my_dest.gid, 0, sizeof my_dest.gid);
+        if (gidx >= 0) {
+                if (ibv_query_gid(ctx->context, ib_port, gidx, &my_dest.gid)) {
+                        gpu_err("Could not get local gid for gid index "
+                                        "%d\n", gidx);
+                        return 1;
+                }
+        } else
+                memset(&my_dest.gid, 0, sizeof my_dest.gid);
 
-	printf("[%d]  local address:  LID 0x%04x, QPN 0x%06x, PSN 0x%06x: GID %s\n",
-	       my_rank, my_dest.lid, my_dest.qpn, my_dest.psn, gid);
-	inet_ntop(AF_INET6, &my_dest.gid, gid, sizeof gid);
+        printf("[%d]  local address:  LID 0x%04x, QPN 0x%06x, PSN 0x%06x: GID %s\n",
+                        my_rank, my_dest.lid, my_dest.qpn, my_dest.psn, gid);
+        inet_ntop(AF_INET6, &my_dest.gid, gid, sizeof gid);
 
-	struct pingpong_dest all_dest[4] = {{0,}};
+        struct pingpong_dest all_dest[4] = {{0,}};
         all_dest[my_rank] = my_dest;
         MPI_CHECK(MPI_Allgather(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL, 
                                 all_dest, sizeof(all_dest[0]), MPI_CHAR, MPI_COMM_WORLD));
         rem_dest = &all_dest[my_rank?0:1];
-	inet_ntop(AF_INET6, &rem_dest->gid, gid, sizeof gid);
+        inet_ntop(AF_INET6, &rem_dest->gid, gid, sizeof gid);
 
-	printf("[%d] remote address: LID 0x%04x, QPN 0x%06x, PSN 0x%06x, GID %s\n",
-	       my_rank, rem_dest->lid, rem_dest->qpn, rem_dest->psn, gid);
+        printf("[%d] remote address: LID 0x%04x, QPN 0x%06x, PSN 0x%06x, GID %s\n",
+                        my_rank, rem_dest->lid, rem_dest->qpn, rem_dest->psn, gid);
 
         if (IBV_QPT_UD == gds_qpt) {
                 struct ibv_qp_attr attr = {
@@ -1270,8 +1270,8 @@ int main(int argc, char *argv[])
                 attr.sq_psn	    = my_dest.psn;
 
                 if (ibv_modify_qp(ctx->qp, &attr,
-                                  IBV_QP_STATE              |
-                                  IBV_QP_SQ_PSN)) {
+                                        IBV_QP_STATE              |
+                                        IBV_QP_SQ_PSN)) {
                         gpu_err("Failed to modify QP to RTS\n");
                         return 1;
                 }
@@ -1299,48 +1299,48 @@ int main(int argc, char *argv[])
                 }
 
         }
-	else {
+        else {
                 struct ibv_qp_attr attr = {
-			.qp_state       = IBV_QPS_RTR,
-			.path_mtu       = ctx->portinfo.active_mtu,
-			.dest_qp_num    = rem_dest->qpn,
-			.rq_psn         = rem_dest->psn,
-			.ah_attr.dlid   = rem_dest->lid,
-			.max_dest_rd_atomic     = 1,
-			.min_rnr_timer          = 12,
-			.ah_attr.is_global      = 0,
-			.ah_attr.sl             = 0,
-			.ah_attr.src_path_bits  = 0,
-			.ah_attr.port_num       = ib_port
+                        .qp_state       = IBV_QPS_RTR,
+                        .path_mtu       = ctx->portinfo.active_mtu,
+                        .dest_qp_num    = rem_dest->qpn,
+                        .rq_psn         = rem_dest->psn,
+                        .ah_attr.dlid   = rem_dest->lid,
+                        .max_dest_rd_atomic     = 1,
+                        .min_rnr_timer          = 12,
+                        .ah_attr.is_global      = 0,
+                        .ah_attr.sl             = 0,
+                        .ah_attr.src_path_bits  = 0,
+                        .ah_attr.port_num       = ib_port
                 };
 
                 if (ibv_modify_qp(ctx->qp, &attr, (IBV_QP_STATE | IBV_QP_AV | IBV_QP_PATH_MTU
-						   | IBV_QP_DEST_QPN | IBV_QP_RQ_PSN
-						   | IBV_QP_MIN_RNR_TIMER | IBV_QP_MAX_DEST_RD_ATOMIC))) {
+                                                | IBV_QP_DEST_QPN | IBV_QP_RQ_PSN
+                                                | IBV_QP_MIN_RNR_TIMER | IBV_QP_MAX_DEST_RD_ATOMIC))) {
                         gpu_err("Failed to modify QP to RTR\n");
                         return 1;
                 }
-		
-		memset(&attr, 0, sizeof(struct ibv_qp_attr));
-		attr.qp_state       = IBV_QPS_RTS;
-		attr.sq_psn         = 0;
-		attr.timeout        = 20;
-		attr.retry_cnt      = 7;
-		attr.rnr_retry      = 7;
-		attr.max_rd_atomic  = 1;
 
-		if (ibv_modify_qp(ctx->qp, &attr, (IBV_QP_STATE | IBV_QP_SQ_PSN | IBV_QP_TIMEOUT
-						     | IBV_QP_RETRY_CNT | IBV_QP_RNR_RETRY
-						   | IBV_QP_MAX_QP_RD_ATOMIC))) {
+                memset(&attr, 0, sizeof(struct ibv_qp_attr));
+                attr.qp_state       = IBV_QPS_RTS;
+                attr.sq_psn         = 0;
+                attr.timeout        = 20;
+                attr.retry_cnt      = 7;
+                attr.rnr_retry      = 7;
+                attr.max_rd_atomic  = 1;
+
+                if (ibv_modify_qp(ctx->qp, &attr, (IBV_QP_STATE | IBV_QP_SQ_PSN | IBV_QP_TIMEOUT
+                                                | IBV_QP_RETRY_CNT | IBV_QP_RNR_RETRY
+                                                | IBV_QP_MAX_QP_RD_ATOMIC))) {
                         gpu_err("Failed to modify QP to RTS\n");
                         return 1;
-		}
-	}
+                }
+        }
 
         MPI_Barrier(MPI_COMM_WORLD);
 
         // for performance reasons, multiple batches back-to-back are posted here
-	ctx->rcnt = 0;
+        ctx->rcnt = 0;
         ctx->scnt = 0;
         ctx->n_tx_ev = 0;
         ctx->n_rx_ev = 0;
@@ -1352,14 +1352,14 @@ int main(int argc, char *argv[])
         int n_post = 0;
         int n_posted = 0;
         int batch;
-	int ii;
+        int ii;
 
-	if (gds_enable_event_prof) {
-		for (ii = 0; ii < MAX_EVENTS; ii++) {
-			cudaEventCreate(&start_time[ii]);
-			cudaEventCreate(&stop_time[ii]);
-		}
-	}
+        if (gds_enable_event_prof) {
+                for (ii = 0; ii < MAX_EVENTS; ii++) {
+                        cudaEventCreate(&start_time[ii]);
+                        cudaEventCreate(&stop_time[ii]);
+                }
+        }
 
         float pre_post_us = 0;
 
@@ -1389,12 +1389,12 @@ int main(int argc, char *argv[])
                         ret = 1;
                         goto out;
                 }
-		float usec = (end.tv_sec - start.tv_sec) * 1000000 +
-			(end.tv_usec - start.tv_usec);
-		printf("pre-posting took %.2f usec\n", usec);
+                float usec = (end.tv_sec - start.tv_sec) * 1000000 +
+                        (end.tv_usec - start.tv_usec);
+                printf("pre-posting took %.2f usec\n", usec);
                 pre_post_us = usec;
         }
-	ctx->pending = PINGPONG_RECV_WRID;
+        ctx->pending = PINGPONG_RECV_WRID;
 
         if (!my_rank) {
                 puts("");
@@ -1407,15 +1407,15 @@ int main(int argc, char *argv[])
                 fflush(stdout);
         }
 
-	if (gettimeofday(&start, NULL)) {
-		perror("gettimeofday");
-		return 1;
-	}
+        if (gettimeofday(&start, NULL)) {
+                perror("gettimeofday");
+                return 1;
+        }
         prof_enable(&prof);
         prof_idx = 0;
         int got_error = 0;
         int iter = 0;
-	while ((ctx->rcnt < iters || ctx->scnt < iters) && !got_error && !stream_cb_error) {
+        while ((ctx->rcnt < iters || ctx->scnt < iters) && !got_error && !stream_cb_error) {
                 ++iter;
                 PROF(&prof, prof_idx++);
 
@@ -1504,8 +1504,8 @@ int main(int argc, char *argv[])
                 }
                 //usleep(10);
                 PROF(&prof, prof_idx++);
-		prof_update(&prof);
-		prof_idx = 0;
+                prof_update(&prof);
+                prof_idx = 0;
 
                 //fprintf(stdout, "%d %d\n", rcnt, scnt); fflush(stdout);
 
@@ -1514,12 +1514,12 @@ int main(int argc, char *argv[])
                         gpu_err("exiting for error\n");
                         return 1;
                 }
-	}
+        }
 
-	if (gettimeofday(&end, NULL)) {
-		perror("gettimeofday");
-		ret = 1;
-	}
+        if (gettimeofday(&end, NULL)) {
+                perror("gettimeofday");
+                ret = 1;
+        }
 
 
         int rid;
@@ -1531,9 +1531,9 @@ int main(int argc, char *argv[])
                         long long bytes = (long long) size * iters * 2;
 
                         printf("[%d] %lld bytes in %.2f seconds = %.2f Mbit/sec\n",
-                               my_rank, bytes, usec / 1000000., bytes * 8. / usec);
+                                        my_rank, bytes, usec / 1000000., bytes * 8. / usec);
                         printf("[%d] %d iters in %.2f seconds = %.2f usec/iter\n",
-                               my_rank, iters, usec / 1000000., usec / iters);
+                                        my_rank, iters, usec / 1000000., usec / iters);
 
                         if (prof_enabled(&prof)) {
                                 printf("[%d] dumping prof\n", my_rank);
@@ -1542,30 +1542,30 @@ int main(int argc, char *argv[])
                 }
         }
 
-	//expect work to be completed by now
+        //expect work to be completed by now
 
-	if (gds_enable_event_prof) {
-		for (ii = 0; ii < event_idx; ii++) {
-			cudaEventElapsedTime(&elapsed_time, start_time[ii], stop_time[ii]);
-			gpu_err("[%d] size = %d, time = %f\n", my_rank, ctx->size, 1000 * elapsed_time);
-		}
-		for (ii = 0; ii < MAX_EVENTS; ii++) {
-			cudaEventDestroy(stop_time[ii]);
-			cudaEventDestroy(start_time[ii]);
-		}
-	} 
+        if (gds_enable_event_prof) {
+                for (ii = 0; ii < event_idx; ii++) {
+                        cudaEventElapsedTime(&elapsed_time, start_time[ii], stop_time[ii]);
+                        gpu_err("[%d] size = %d, time = %f\n", my_rank, ctx->size, 1000 * elapsed_time);
+                }
+                for (ii = 0; ii < MAX_EVENTS; ii++) {
+                        cudaEventDestroy(stop_time[ii]);
+                        cudaEventDestroy(start_time[ii]);
+                }
+        } 
 
         MPI_Barrier(MPI_COMM_WORLD);
-	if (pp_close_ctx(ctx))
-		ret = 1;
+        if (pp_close_ctx(ctx))
+                ret = 1;
 
-	ibv_free_device_list(dev_list);
-	//free(rem_dest);
+        ibv_free_device_list(dev_list);
+        //free(rem_dest);
 
         MPI_Barrier(MPI_COMM_WORLD);
         MPI_Finalize();
 out:
-	return ret;
+        return ret;
 }
 
 /*

--- a/tests/gds_kernel_latency.c
+++ b/tests/gds_kernel_latency.c
@@ -542,8 +542,8 @@ static int pp_post_gpu_send(struct pingpong_context *ctx, uint32_t qpn, CUstream
 		.wr_id	    = PINGPONG_SEND_WRID,
 		.sg_list    = &list,
 		.num_sge    = 1,
-		.exp_opcode = IBV_EXP_WR_SEND,
-		.exp_send_flags = IBV_EXP_SEND_SIGNALED,
+		.opcode = IBV_WR_SEND,
+		.send_flags = IBV_SEND_SIGNALED,
 		.wr         = {
 			.ud = {
 				 .ah          = ctx->ah,
@@ -551,7 +551,6 @@ static int pp_post_gpu_send(struct pingpong_context *ctx, uint32_t qpn, CUstream
 				 .remote_qkey = 0x11111111
 			 }
 		},
-		.comp_mask = 0
 	};
 #if 0
 	if (IBV_QPT_UD != gds_qpt) {
@@ -580,8 +579,8 @@ static int pp_prepare_gpu_send(struct pingpong_context *ctx, uint32_t qpn, gds_s
 		.wr_id	    = PINGPONG_SEND_WRID,
 		.sg_list    = &list,
 		.num_sge    = 1,
-		.exp_opcode = IBV_EXP_WR_SEND,
-		.exp_send_flags = IBV_EXP_SEND_SIGNALED,
+		.opcode = IBV_WR_SEND,
+		.send_flags = IBV_SEND_SIGNALED,
 		.wr         = {
 			.ud = {
 				 .ah          = ctx->ah,
@@ -589,14 +588,13 @@ static int pp_prepare_gpu_send(struct pingpong_context *ctx, uint32_t qpn, gds_s
 				 .remote_qkey = 0x11111111
 			 }
 		},
-		.comp_mask = 0
 	};
 	
 	if (IBV_QPT_UD != gds_qpt) {
 		memset(&ewr, 0, sizeof(ewr));
 		ewr.num_sge = 1;
-		ewr.exp_send_flags = IBV_EXP_SEND_SIGNALED;
-		ewr.exp_opcode = IBV_EXP_WR_SEND;
+		ewr.send_flags = IBV_SEND_SIGNALED;
+		ewr.opcode = IBV_WR_SEND;
 		ewr.wr_id = PINGPONG_SEND_WRID;
 		ewr.sg_list = &list;
 		ewr.next = NULL;

--- a/tests/gds_kernel_latency.c
+++ b/tests/gds_kernel_latency.c
@@ -124,7 +124,7 @@ struct pingpong_context {
 	struct ibv_cq		*tx_cq;
 	struct ibv_cq		*rx_cq;
 	struct ibv_qp		*qp;
-	gds_qp_t		    *gds_qp;
+    gds_qp_t            *gds_qp;
 	struct ibv_ah		*ah;
 	void			*buf;
 	char			*txbuf;

--- a/tests/gds_kernel_latency.c
+++ b/tests/gds_kernel_latency.c
@@ -678,7 +678,7 @@ static int pp_post_work(struct pingpong_context *ctx, int n_posts, int rcnt, uin
                                 }
                                 assert(k < N_WORK_DESCS);
                                 wdesc->descs[k].tag = GDS_TAG_SEND;
-                                wdesc->descs[k].send = wdesc->send_rq;
+                                wdesc->descs[k].send = &wdesc->send_rq;
                                 ++k;
                                 ret = gds_prepare_wait_cq(&ctx->gds_qp->send_cq, &wdesc->wait_tx_rq, 0);
                                 if (ret) {
@@ -687,7 +687,7 @@ static int pp_post_work(struct pingpong_context *ctx, int n_posts, int rcnt, uin
                                 }
                                 assert(k < N_WORK_DESCS);
                                 wdesc->descs[k].tag = GDS_TAG_WAIT;
-                                wdesc->descs[k].wait = wdesc->wait_tx_rq;
+                                wdesc->descs[k].wait = &wdesc->wait_tx_rq;
                                 ++k;
                                 ret = gds_prepare_wait_cq(&ctx->gds_qp->recv_cq, &wdesc->wait_rx_rq, 0);
                                 if (ret) {
@@ -696,7 +696,7 @@ static int pp_post_work(struct pingpong_context *ctx, int n_posts, int rcnt, uin
                                 }
                                 assert(k < N_WORK_DESCS);
                                 wdesc->descs[k].tag = GDS_TAG_WAIT;
-                                wdesc->descs[k].wait = wdesc->wait_rx_rq;
+                                wdesc->descs[k].wait = &wdesc->wait_rx_rq;
                                 ++k;
                                 wdesc->n_descs = k;
                                 if (ctx->peersync) {
@@ -767,7 +767,7 @@ static int pp_post_work(struct pingpong_context *ctx, int n_posts, int rcnt, uin
                                 }
                                 assert(k < N_WORK_DESCS);
                                 wdesc->descs[k].tag = GDS_TAG_WAIT;
-                                wdesc->descs[k].wait = wdesc->wait_rx_rq;
+                                wdesc->descs[k].wait = &wdesc->wait_rx_rq;
                                 ++k;
                                 wdesc->n_descs = k;
                                 if (ctx->peersync) {
@@ -818,7 +818,7 @@ static int pp_post_work(struct pingpong_context *ctx, int n_posts, int rcnt, uin
                                 }
                                 assert(k < N_WORK_DESCS);
                                 wdesc->descs[k].tag = GDS_TAG_SEND;
-                                wdesc->descs[k].send = wdesc->send_rq;
+                                wdesc->descs[k].send = &wdesc->send_rq;
                                 ++k;
                                 ret = gds_prepare_wait_cq(&ctx->gds_qp->send_cq, &wdesc->wait_tx_rq, 0);
                                 if (ret) {
@@ -827,7 +827,7 @@ static int pp_post_work(struct pingpong_context *ctx, int n_posts, int rcnt, uin
                                 }
                                 assert(k < N_WORK_DESCS);
                                 wdesc->descs[k].tag = GDS_TAG_WAIT;
-                                wdesc->descs[k].wait = wdesc->wait_tx_rq;
+                                wdesc->descs[k].wait = &wdesc->wait_tx_rq;
                                 ++k;
                                 wdesc->n_descs = k;
                                 if (ctx->peersync) {

--- a/tests/gds_kernel_latency.c
+++ b/tests/gds_kernel_latency.c
@@ -492,6 +492,7 @@ static int pp_post_recv(struct pingpong_context *ctx, int n)
 	return i;
 }
 
+#if 0
 static int pp_wait_cq(struct pingpong_context *ctx, int is_client)
 {
         int ret;
@@ -530,10 +531,10 @@ static int pp_wait_cq(struct pingpong_context *ctx, int is_client)
         }
         return ret;
 }
+#endif
 
 static int pp_post_gpu_send(struct pingpong_context *ctx, uint32_t qpn, CUstream *p_gpu_stream)
 {
-        int ret = 0;
 	struct ibv_sge list = {
 		.addr	= (uintptr_t) ctx->txbuf,
 		.length = ctx->size,
@@ -570,7 +571,6 @@ static int pp_post_gpu_send(struct pingpong_context *ctx, uint32_t qpn, CUstream
 
 static int pp_prepare_gpu_send(struct pingpong_context *ctx, uint32_t qpn, gds_send_request_t *req)
 {
-        int ret = 0;
 	struct ibv_sge list = {
 		.addr	= (uintptr_t) ctx->txbuf,
 		.length = ctx->size,
@@ -960,7 +960,7 @@ int main(int argc, char *argv[])
 	struct pingpong_context *ctx;
 	struct pingpong_dest     my_dest;
 	struct pingpong_dest    *rem_dest = NULL;
-	struct timeval           rstart, start, end;
+	struct timeval           start, end;
 	const char              *ib_devname = NULL;
 	char                    *servername = NULL;
 	int                      port = 18515;
@@ -972,7 +972,6 @@ int main(int argc, char *argv[])
 	int                      use_event = 0;
 	int                      routs;
         int                      nposted;
-	int                      num_cq_events = 0;
 	int                      sl = 0;
 	int			 gidx = -1;
 	char			 gid[INET6_ADDRSTRLEN];
@@ -980,7 +979,6 @@ int main(int argc, char *argv[])
         int                      peersync = 1;
         int                      peersync_gpu_cq = 0;
         int                      peersync_gpu_dbrec = 0;
-        int                      warmup = 10;
         int                      consume_rx_cqe = 0;
 	int                      gds_qp_type = 1;
         int                      sched_mode = CU_CTX_SCHED_AUTO;
@@ -1588,8 +1586,6 @@ int main(int argc, char *argv[])
                         }
                 }
         }
-
-	//ibv_ack_cq_events(ctx->cq, num_cq_events);
 
 	//expect work to be completed by now
 

--- a/tests/gds_kernel_latency.c
+++ b/tests/gds_kernel_latency.c
@@ -54,6 +54,7 @@
 #include <arpa/inet.h>
 #include <time.h>
 #include <assert.h>
+#include <errno.h>
 
 #include <cuda.h>
 #include <cuda_runtime_api.h>
@@ -604,15 +605,60 @@ static int pp_prepare_gpu_send(struct pingpong_context *ctx, uint32_t qpn, gds_s
 }
 
 typedef struct work_desc {
-        gds_send_request_t send_rq;
-        gds_wait_request_t wait_tx_rq;
-        gds_wait_request_t wait_rx_rq;
+        gds_send_request_t *send_rq;
+        gds_wait_request_t *wait_tx_rq;
+        gds_wait_request_t *wait_rx_rq;
 #define N_WORK_DESCS 3
         gds_descriptor_t descs[N_WORK_DESCS];
         unsigned n_descs;
 } work_desc_t;
 
-static void post_work_cb(CUstream hStream, CUresult status, void *userData)\
+static void free_work_desc(work_desc_t *wdesc)
+{
+    if (!wdesc)
+        return;
+
+    if (wdesc->send_rq)
+        gds_free_send_request(wdesc->send_rq);
+
+    if (wdesc->wait_tx_rq)
+        gds_free_wait_request(wdesc->wait_tx_rq);
+
+    if (wdesc->wait_rx_rq)
+        gds_free_wait_request(wdesc->wait_rx_rq);
+
+    free(wdesc);
+}
+
+static int alloc_work_desc(work_desc_t **wdesc)
+{
+    *wdesc = (work_desc_t *)calloc(1, sizeof(work_desc_t));
+    if (*wdesc == NULL)
+        goto err;
+
+    if (gds_alloc_send_request(&(*wdesc)->send_rq, 1) != 0) {
+        gpu_err("[%d] cannot alloc send_rq\n", my_rank);
+        goto err;
+    }
+
+    if (gds_alloc_wait_request(&(*wdesc)->wait_tx_rq, 1) != 0) {
+        gpu_err("[%d] cannot alloc wait_tx_rq\n", my_rank);
+        goto err;
+    }
+
+    if (gds_alloc_wait_request(&(*wdesc)->wait_rx_rq, 1) != 0) {
+        gpu_err("[%d] cannot alloc wait_rx_rq\n", my_rank);
+        goto err;
+    }
+
+    return 0;
+
+err:
+    free_work_desc(*wdesc);
+    return -ENOMEM;
+}
+
+static void post_work_cb(CUstream hStream, CUresult status, void *userData)
 {
         int retcode;
         work_desc_t *wdesc = (work_desc_t *)userData;
@@ -630,7 +676,7 @@ static void post_work_cb(CUstream hStream, CUresult status, void *userData)\
                 stream_cb_error = 1;
         }
 out:
-        free(wdesc);
+        free_work_desc(wdesc);
         NVTX_POP();
 }
 
@@ -663,39 +709,44 @@ static int pp_post_work(struct pingpong_context *ctx, int n_posts, int rcnt, uin
 				cudaEventRecord(start_time[event_idx], gpu_stream);
 			}
                         if (ctx->use_desc_apis) {
-                                work_desc_t *wdesc = calloc(1, sizeof(*wdesc));
+                                work_desc_t *wdesc;
+                                if (alloc_work_desc(&wdesc) != 0) {
+                                    gpu_err("[%d] cannot alloc work desc\n", my_rank);
+                                    exit(EXIT_FAILURE);
+                                }
+
                                 int k = 0;
-                                ret = pp_prepare_gpu_send(ctx, qpn, &wdesc->send_rq);
+                                ret = pp_prepare_gpu_send(ctx, qpn, wdesc->send_rq);
                                 if (ret) {
                                         retcode = -ret;
                                         break;
                                 }
                                 assert(k < N_WORK_DESCS);
                                 wdesc->descs[k].tag = GDS_TAG_SEND;
-                                wdesc->descs[k].send = &wdesc->send_rq;
+                                wdesc->descs[k].send = wdesc->send_rq;
                                 ++k;
-                                ret = gds_prepare_wait_cq(&ctx->gds_qp->send_cq, &wdesc->wait_tx_rq, 0);
+                                ret = gds_prepare_wait_cq(&ctx->gds_qp->send_cq, wdesc->wait_tx_rq, 0);
                                 if (ret) {
                                         retcode = -ret;
                                         break;
                                 }
                                 assert(k < N_WORK_DESCS);
                                 wdesc->descs[k].tag = GDS_TAG_WAIT;
-                                wdesc->descs[k].wait = &wdesc->wait_tx_rq;
+                                wdesc->descs[k].wait = wdesc->wait_tx_rq;
                                 ++k;
-                                ret = gds_prepare_wait_cq(&ctx->gds_qp->recv_cq, &wdesc->wait_rx_rq, 0);
+                                ret = gds_prepare_wait_cq(&ctx->gds_qp->recv_cq, wdesc->wait_rx_rq, 0);
                                 if (ret) {
                                         retcode = -ret;
                                         break;
                                 }
                                 assert(k < N_WORK_DESCS);
                                 wdesc->descs[k].tag = GDS_TAG_WAIT;
-                                wdesc->descs[k].wait = &wdesc->wait_rx_rq;
+                                wdesc->descs[k].wait = wdesc->wait_rx_rq;
                                 ++k;
                                 wdesc->n_descs = k;
                                 if (ctx->peersync) {
                                         ret = gds_stream_post_descriptors(gpu_stream, k, wdesc->descs, 0);
-                                        free(wdesc);
+                                        free_work_desc(wdesc);
                                         if (ret) {
                                                 retcode = -ret;
                                                 break;
@@ -747,21 +798,26 @@ static int pp_post_work(struct pingpong_context *ctx, int n_posts, int rcnt, uin
                 } else { // !is_client == server
 
                         if (ctx->use_desc_apis) {
-                                work_desc_t *wdesc = calloc(1, sizeof(*wdesc));
+                                work_desc_t *wdesc;
+                                if (alloc_work_desc(&wdesc) != 0) {
+                                    gpu_err("[%d] cannot alloc work desc\n", my_rank);
+                                    exit(EXIT_FAILURE);
+                                }
+
                                 int k = 0;
-                                ret = gds_prepare_wait_cq(&ctx->gds_qp->recv_cq, &wdesc->wait_rx_rq, 0);
+                                ret = gds_prepare_wait_cq(&ctx->gds_qp->recv_cq, wdesc->wait_rx_rq, 0);
                                 if (ret) {
                                         retcode = -ret;
                                         break;
                                 }
                                 assert(k < N_WORK_DESCS);
                                 wdesc->descs[k].tag = GDS_TAG_WAIT;
-                                wdesc->descs[k].wait = &wdesc->wait_rx_rq;
+                                wdesc->descs[k].wait = wdesc->wait_rx_rq;
                                 ++k;
                                 wdesc->n_descs = k;
                                 if (ctx->peersync) {
                                         ret = gds_stream_post_descriptors(gpu_stream, k, wdesc->descs, 0);
-                                        free(wdesc);
+                                        free_work_desc(wdesc);
                                         if (ret) {
                                                 retcode = -ret;
                                                 break;
@@ -793,30 +849,35 @@ static int pp_post_work(struct pingpong_context *ctx, int n_posts, int rcnt, uin
 				cudaEventRecord(start_time[event_idx], gpu_stream);
 			} 
                         if (ctx->use_desc_apis) {
-                                work_desc_t *wdesc = calloc(1, sizeof(*wdesc));
+                                work_desc_t *wdesc;
+                                if (alloc_work_desc(&wdesc) != 0) {
+                                    gpu_err("[%d] cannot alloc work desc\n", my_rank);
+                                    exit(EXIT_FAILURE);
+                                }
+
                                 int k = 0;
-                                ret = pp_prepare_gpu_send(ctx, qpn, &wdesc->send_rq);
+                                ret = pp_prepare_gpu_send(ctx, qpn, wdesc->send_rq);
                                 if (ret) {
                                         retcode = -ret;
                                         break;
                                 }
                                 assert(k < N_WORK_DESCS);
                                 wdesc->descs[k].tag = GDS_TAG_SEND;
-                                wdesc->descs[k].send = &wdesc->send_rq;
+                                wdesc->descs[k].send = wdesc->send_rq;
                                 ++k;
-                                ret = gds_prepare_wait_cq(&ctx->gds_qp->send_cq, &wdesc->wait_tx_rq, 0);
+                                ret = gds_prepare_wait_cq(&ctx->gds_qp->send_cq, wdesc->wait_tx_rq, 0);
                                 if (ret) {
                                         retcode = -ret;
                                         break;
                                 }
                                 assert(k < N_WORK_DESCS);
                                 wdesc->descs[k].tag = GDS_TAG_WAIT;
-                                wdesc->descs[k].wait = &wdesc->wait_tx_rq;
+                                wdesc->descs[k].wait = wdesc->wait_tx_rq;
                                 ++k;
                                 wdesc->n_descs = k;
                                 if (ctx->peersync) {
                                         ret = gds_stream_post_descriptors(gpu_stream, k, wdesc->descs, 0);
-                                        free(wdesc);
+                                        free_work_desc(wdesc);
                                         if (ret) {
                                                 retcode = -ret;
                                                 break;

--- a/tests/gds_kernel_loopback_latency.c
+++ b/tests/gds_kernel_loopback_latency.c
@@ -79,36 +79,36 @@ int prof_idx = 0;
 #define USE_CUDA_PROFILER 1
 
 enum {
-	PINGPONG_RECV_WRID = 1,
-	PINGPONG_SEND_WRID = 2,
+        PINGPONG_RECV_WRID = 1,
+        PINGPONG_SEND_WRID = 2,
 };
 
 static int page_size;
 int stream_cb_error = 0;
 
 struct pingpong_context {
-	struct ibv_context	*context;
-	struct ibv_comp_channel *channel;
-	struct ibv_pd		*pd;
-	struct ibv_mr		*mr;
-	struct ibv_cq		*tx_cq;
-	struct ibv_cq		*rx_cq;
-	struct ibv_qp		*qp;
-	gds_qp_t    		*gds_qp;
-	struct ibv_ah		*ah;
-	void			*buf;
-	char			*txbuf;
+        struct ibv_context	*context;
+        struct ibv_comp_channel *channel;
+        struct ibv_pd		*pd;
+        struct ibv_mr		*mr;
+        struct ibv_cq		*tx_cq;
+        struct ibv_cq		*rx_cq;
+        struct ibv_qp		*qp;
+        gds_qp_t    		*gds_qp;
+        struct ibv_ah		*ah;
+        void			*buf;
+        char			*txbuf;
         char                    *rxbuf;
         char                    *rx_flag;
-	int			 size;
+        int			 size;
         int                      calc_size;
-	int			 rx_depth;
-	int			 pending;
-	struct ibv_port_attr     portinfo;
-	int                      gpu_id;
-	int                      kernel_duration;
-	int                      peersync;
-	int                      peersync_gpu_cq;
+        int			 rx_depth;
+        int			 pending;
+        struct ibv_port_attr     portinfo;
+        int                      gpu_id;
+        int                      kernel_duration;
+        int                      peersync;
+        int                      peersync_gpu_cq;
         int                      consume_rx_cqe;
         int                      gpumem;
         int                      use_desc_apis;
@@ -118,137 +118,137 @@ struct pingpong_context {
 static int my_rank = 0, comm_size = 1;
 
 struct pingpong_dest {
-	int lid;
-	int qpn;
-	int psn;
-	union ibv_gid gid;
+        int lid;
+        int qpn;
+        int psn;
+        union ibv_gid gid;
 };
 
 static int pp_connect_ctx(struct pingpong_context *ctx, int port, int my_psn,
-			  int sl, struct pingpong_dest *dest, int sgid_idx)
+                int sl, struct pingpong_dest *dest, int sgid_idx)
 {
-	struct ibv_ah_attr ah_attr = {
-		.is_global     = 0,
-		.dlid          = dest->lid,
-		.sl            = sl,
-		.src_path_bits = 0,
-		.port_num      = port
-	};
-	struct ibv_qp_attr attr = {
-		.qp_state		= IBV_QPS_RTR
-	};
+        struct ibv_ah_attr ah_attr = {
+                .is_global     = 0,
+                .dlid          = dest->lid,
+                .sl            = sl,
+                .src_path_bits = 0,
+                .port_num      = port
+        };
+        struct ibv_qp_attr attr = {
+                .qp_state		= IBV_QPS_RTR
+        };
 
-	if (ibv_modify_qp(ctx->qp, &attr, IBV_QP_STATE)) {
-		fprintf(stderr, "Failed to modify QP to RTR\n");
-		return 1;
-	}
+        if (ibv_modify_qp(ctx->qp, &attr, IBV_QP_STATE)) {
+                fprintf(stderr, "Failed to modify QP to RTR\n");
+                return 1;
+        }
 
-	attr.qp_state	    = IBV_QPS_RTS;
-	attr.sq_psn	    = my_psn;
+        attr.qp_state	    = IBV_QPS_RTS;
+        attr.sq_psn	    = my_psn;
 
-	if (ibv_modify_qp(ctx->qp, &attr,
-			  IBV_QP_STATE              |
-			  IBV_QP_SQ_PSN)) {
-		fprintf(stderr, "Failed to modify QP to RTS\n");
-		return 1;
-	}
+        if (ibv_modify_qp(ctx->qp, &attr,
+                                IBV_QP_STATE              |
+                                IBV_QP_SQ_PSN)) {
+                fprintf(stderr, "Failed to modify QP to RTS\n");
+                return 1;
+        }
 
-	if (dest->gid.global.interface_id) {
-		ah_attr.is_global = 1;
-		ah_attr.grh.hop_limit = 1;
-		ah_attr.grh.dgid = dest->gid;
-		ah_attr.grh.sgid_index = sgid_idx;
-	}
+        if (dest->gid.global.interface_id) {
+                ah_attr.is_global = 1;
+                ah_attr.grh.hop_limit = 1;
+                ah_attr.grh.dgid = dest->gid;
+                ah_attr.grh.sgid_index = sgid_idx;
+        }
 
-	ctx->ah = ibv_create_ah(ctx->pd, &ah_attr);
-	if (!ctx->ah) {
-		fprintf(stderr, "Failed to create AH\n");
-		return 1;
-	}
+        ctx->ah = ibv_create_ah(ctx->pd, &ah_attr);
+        if (!ctx->ah) {
+                fprintf(stderr, "Failed to create AH\n");
+                return 1;
+        }
 
-	return 0;
+        return 0;
 }
 
 static struct pingpong_dest *pp_client_exch_dest(const char *servername, int port,
-						 const struct pingpong_dest *my_dest)
+                const struct pingpong_dest *my_dest)
 {
-	struct addrinfo *res, *t;
-	struct addrinfo hints = {
-		.ai_family   = AF_UNSPEC,
-		.ai_socktype = SOCK_STREAM
-	};
-	char *service;
-	char msg[sizeof "0000:000000:000000:00000000000000000000000000000000"];
-	int n;
-	int sockfd = -1;
-	struct pingpong_dest *rem_dest = NULL;
-	char gid[33];
-	
-	fprintf(stderr, "%04x:%06x:%06x:%s\n", my_dest->lid, my_dest->qpn,
-                my_dest->psn, (char *)&my_dest->gid);
-	rem_dest = malloc(sizeof *rem_dest);
-	if (!rem_dest)
-		goto out;
-	memcpy(rem_dest, my_dest, sizeof(struct pingpong_dest));
-	//rem_dest->gid = my_dest->gid;
-	fprintf(stderr, "%04x:%06x:%06x\n", rem_dest->lid, rem_dest->qpn,
-		rem_dest->psn);
+        struct addrinfo *res, *t;
+        struct addrinfo hints = {
+                .ai_family   = AF_UNSPEC,
+                .ai_socktype = SOCK_STREAM
+        };
+        char *service;
+        char msg[sizeof "0000:000000:000000:00000000000000000000000000000000"];
+        int n;
+        int sockfd = -1;
+        struct pingpong_dest *rem_dest = NULL;
+        char gid[33];
+
+        fprintf(stderr, "%04x:%06x:%06x:%s\n", my_dest->lid, my_dest->qpn,
+                        my_dest->psn, (char *)&my_dest->gid);
+        rem_dest = malloc(sizeof *rem_dest);
+        if (!rem_dest)
+                goto out;
+        memcpy(rem_dest, my_dest, sizeof(struct pingpong_dest));
+        //rem_dest->gid = my_dest->gid;
+        fprintf(stderr, "%04x:%06x:%06x\n", rem_dest->lid, rem_dest->qpn,
+                        rem_dest->psn);
 
 out:
-	return rem_dest;
+        return rem_dest;
 }
 
 static inline unsigned long align_to(unsigned long val, unsigned long pow2)
 {
-	return (val + pow2 - 1) & ~(pow2 - 1);
+        return (val + pow2 - 1) & ~(pow2 - 1);
 }
 
 static struct pingpong_context *pp_init_ctx(struct ibv_device *ib_dev, int size, int calc_size,
-					    int rx_depth, int port,
-					    int use_event,
-					    int gpu_id,
-                                            int peersync,
-                                            int peersync_gpu_cq,
-                                            int peersync_gpu_dbrec,
-                                            int consume_rx_cqe,
-                                            int sched_mode,
-                                            int use_gpumem,
-                                            int use_desc_apis,
-                                            int skip_kernel_launch)
+        int rx_depth, int port,
+        int use_event,
+        int gpu_id,
+        int peersync,
+        int peersync_gpu_cq,
+        int peersync_gpu_dbrec,
+        int consume_rx_cqe,
+        int sched_mode,
+        int use_gpumem,
+        int use_desc_apis,
+        int skip_kernel_launch)
 {
-	struct pingpong_context *ctx;
+        struct pingpong_context *ctx;
 
-	if (gpu_id >=0 && gpu_init(gpu_id, sched_mode)) {
-		fprintf(stderr, "error in GPU init.\n");
-		return NULL;
-	}
+        if (gpu_id >=0 && gpu_init(gpu_id, sched_mode)) {
+                fprintf(stderr, "error in GPU init.\n");
+                return NULL;
+        }
 
-	ctx = malloc(sizeof *ctx);
-	if (!ctx)
-		return NULL;
+        ctx = malloc(sizeof *ctx);
+        if (!ctx)
+                return NULL;
 
-	ctx->size     = size;
-	ctx->calc_size = calc_size;
-	ctx->rx_depth = rx_depth;
-	ctx->gpu_id   = gpu_id;
+        ctx->size     = size;
+        ctx->calc_size = calc_size;
+        ctx->rx_depth = rx_depth;
+        ctx->gpu_id   = gpu_id;
         ctx->gpumem   = use_gpumem;
         ctx->use_desc_apis = use_desc_apis;
         ctx->skip_kernel_launch = skip_kernel_launch;
 
         size_t alloc_size = 3 * align_to(size + 40, page_size);
-	if (ctx->gpumem) {
-		ctx->buf = gpu_malloc(page_size, alloc_size);
+        if (ctx->gpumem) {
+                ctx->buf = gpu_malloc(page_size, alloc_size);
                 printf("allocated GPU buffer address at %p\n", ctx->buf);
-	} else {
+        } else {
                 printf("allocating CPU memory buf\n");
-		ctx->buf = memalign(page_size, alloc_size);
+                ctx->buf = memalign(page_size, alloc_size);
                 printf("allocated CPU buffer address at %p\n", ctx->buf);
         }
 
-	if (!ctx->buf) {
-		fprintf(stderr, "Couldn't allocate work buf.\n");
-		goto clean_ctx;
-	}
+        if (!ctx->buf) {
+                fprintf(stderr, "Couldn't allocate work buf.\n");
+                goto clean_ctx;
+        }
         printf("ctx buf=%p\n", ctx->buf);
         ctx->rxbuf = (char*)ctx->buf;
         ctx->txbuf = (char*)ctx->buf + align_to(size + 40, page_size);
@@ -260,16 +260,16 @@ static struct pingpong_context *pp_init_ctx(struct ibv_device *ib_dev, int size,
                 goto clean_ctx;
         }
 
-	ctx->kernel_duration = 0;
-	ctx->peersync = peersync;
+        ctx->kernel_duration = 0;
+        ctx->peersync = peersync;
         ctx->peersync_gpu_cq = peersync_gpu_cq;
         ctx->consume_rx_cqe = consume_rx_cqe;
 
         // must be ZERO!!! for rx_flag to work...
-	if (ctx->gpumem)
-		gpu_memset(ctx->buf, 0, alloc_size);
-	else
-		memset(ctx->buf, 0, alloc_size);
+        if (ctx->gpumem)
+                gpu_memset(ctx->buf, 0, alloc_size);
+        else
+                memset(ctx->buf, 0, alloc_size);
 
         memset(ctx->rx_flag, 0, alloc_size);
         //gpu_register_host_mem(ctx->rx_flag, alloc_size);
@@ -286,34 +286,34 @@ static struct pingpong_context *pp_init_ctx(struct ibv_device *ib_dev, int size,
                 CUCHECK(cuCtxSynchronize());
         }
 
-	ctx->context = ibv_open_device(ib_dev);
-	if (!ctx->context) {
-		fprintf(stderr, "Couldn't get context for %s\n",
-			ibv_get_device_name(ib_dev));
-		goto clean_buffer;
-	}
+        ctx->context = ibv_open_device(ib_dev);
+        if (!ctx->context) {
+                fprintf(stderr, "Couldn't get context for %s\n",
+                                ibv_get_device_name(ib_dev));
+                goto clean_buffer;
+        }
 
-	if (use_event) {
-		ctx->channel = ibv_create_comp_channel(ctx->context);
-		if (!ctx->channel) {
-			fprintf(stderr, "Couldn't create completion channel\n");
-			goto clean_device;
-		}
-	} else
-		ctx->channel = NULL;
+        if (use_event) {
+                ctx->channel = ibv_create_comp_channel(ctx->context);
+                if (!ctx->channel) {
+                        fprintf(stderr, "Couldn't create completion channel\n");
+                        goto clean_device;
+                }
+        } else
+                ctx->channel = NULL;
 
-	ctx->pd = ibv_alloc_pd(ctx->context);
-	if (!ctx->pd) {
-		fprintf(stderr, "Couldn't allocate PD\n");
-		goto clean_comp_channel;
-	}
+        ctx->pd = ibv_alloc_pd(ctx->context);
+        if (!ctx->pd) {
+                fprintf(stderr, "Couldn't allocate PD\n");
+                goto clean_comp_channel;
+        }
 
         //printf("BEFORE reg_mr(), sleeping 2s\n"); sleep(2);
-	ctx->mr = ibv_reg_mr(ctx->pd, ctx->buf, alloc_size, IBV_ACCESS_LOCAL_WRITE);
-	if (!ctx->mr) {
-		fprintf(stderr, "Couldn't register MR\n");
-		goto clean_pd;
-	}
+        ctx->mr = ibv_reg_mr(ctx->pd, ctx->buf, alloc_size, IBV_ACCESS_LOCAL_WRITE);
+        if (!ctx->mr) {
+                fprintf(stderr, "Couldn't register MR\n");
+                goto clean_pd;
+        }
         //printf("AFTER reg_mr(), sleeping 2s\n"); sleep(2);
 
         int gds_flags = 0;
@@ -333,8 +333,8 @@ static struct pingpong_context *pp_init_ctx(struct ibv_device *ib_dev, int size,
                 },
                 .qp_type = IBV_QPT_UD,
         };
-	
-	//why?
+
+        //why?
         if (my_rank == 1) {
                 printf("sleeping 2s\n");
                 sleep(2);
@@ -344,100 +344,100 @@ static struct pingpong_context *pp_init_ctx(struct ibv_device *ib_dev, int size,
         if (!ctx->gds_qp) {
                 fprintf(stderr, "Couldn't create QP (%d/%s)\n", errno, strerror(errno));
                 goto clean_mr;
-	}
+        }
         ctx->qp = ctx->gds_qp->qp;
         ctx->tx_cq = ctx->gds_qp->qp->send_cq;
         ctx->rx_cq = ctx->gds_qp->qp->recv_cq;
 
-	{
-		struct ibv_qp_attr attr = {
-			.qp_state        = IBV_QPS_INIT,
-			.pkey_index      = 0,
-			.port_num        = port,
-			.qkey            = 0x11111111
-		};
+        {
+                struct ibv_qp_attr attr = {
+                        .qp_state        = IBV_QPS_INIT,
+                        .pkey_index      = 0,
+                        .port_num        = port,
+                        .qkey            = 0x11111111
+                };
 
-		if (ibv_modify_qp(ctx->qp, &attr,
-				  IBV_QP_STATE              |
-				  IBV_QP_PKEY_INDEX         |
-				  IBV_QP_PORT               |
-				  IBV_QP_QKEY)) {
-			fprintf(stderr, "Failed to modify QP to INIT\n");
-			goto clean_qp;
-		}
-	}
+                if (ibv_modify_qp(ctx->qp, &attr,
+                                        IBV_QP_STATE              |
+                                        IBV_QP_PKEY_INDEX         |
+                                        IBV_QP_PORT               |
+                                        IBV_QP_QKEY)) {
+                        fprintf(stderr, "Failed to modify QP to INIT\n");
+                        goto clean_qp;
+                }
+        }
 
-	return ctx;
+        return ctx;
 
 clean_qp:
-	gds_destroy_qp(ctx->gds_qp);
+        gds_destroy_qp(ctx->gds_qp);
 
 clean_mr:
-	ibv_dereg_mr(ctx->mr);
+        ibv_dereg_mr(ctx->mr);
 
 clean_pd:
-	ibv_dealloc_pd(ctx->pd);
+        ibv_dealloc_pd(ctx->pd);
 
 clean_comp_channel:
-	if (ctx->channel)
-		ibv_destroy_comp_channel(ctx->channel);
+        if (ctx->channel)
+                ibv_destroy_comp_channel(ctx->channel);
 
 clean_device:
-	ibv_close_device(ctx->context);
+        ibv_close_device(ctx->context);
 
 clean_buffer:
-	if (ctx->gpumem)
-		gpu_free(ctx->buf); 
-	else 
-		free(ctx->buf);
+        if (ctx->gpumem)
+                gpu_free(ctx->buf); 
+        else 
+                free(ctx->buf);
 
 clean_ctx:
-	if (ctx->gpu_id >= 0)
-		gpu_finalize();
-	free(ctx);
+        if (ctx->gpu_id >= 0)
+                gpu_finalize();
+        free(ctx);
 
-	return NULL;
+        return NULL;
 }
 
 int pp_close_ctx(struct pingpong_context *ctx)
 {
-	if (gds_destroy_qp(ctx->gds_qp)) {
-		fprintf(stderr, "Couldn't destroy QP\n");
-	}
+        if (gds_destroy_qp(ctx->gds_qp)) {
+                fprintf(stderr, "Couldn't destroy QP\n");
+        }
 
-	if (ibv_dereg_mr(ctx->mr)) {
-		fprintf(stderr, "Couldn't deregister MR\n");
-	}
+        if (ibv_dereg_mr(ctx->mr)) {
+                fprintf(stderr, "Couldn't deregister MR\n");
+        }
 
-	if (ibv_destroy_ah(ctx->ah)) {
-		fprintf(stderr, "Couldn't destroy AH\n");
-	}
+        if (ibv_destroy_ah(ctx->ah)) {
+                fprintf(stderr, "Couldn't destroy AH\n");
+        }
 
-	if (ibv_dealloc_pd(ctx->pd)) {
-		fprintf(stderr, "Couldn't deallocate PD\n");
-	}
+        if (ibv_dealloc_pd(ctx->pd)) {
+                fprintf(stderr, "Couldn't deallocate PD\n");
+        }
 
-	if (ctx->channel) {
-		if (ibv_destroy_comp_channel(ctx->channel)) {
-			fprintf(stderr, "Couldn't destroy completion channel\n");
-		}
-	}
+        if (ctx->channel) {
+                if (ibv_destroy_comp_channel(ctx->channel)) {
+                        fprintf(stderr, "Couldn't destroy completion channel\n");
+                }
+        }
 
-	if (ibv_close_device(ctx->context)) {
-		fprintf(stderr, "Couldn't release context\n");
-	}
+        if (ibv_close_device(ctx->context)) {
+                fprintf(stderr, "Couldn't release context\n");
+        }
 
-	if (ctx->gpumem)
-		gpu_free(ctx->buf); 
-	else 
-		free(ctx->buf);
+        if (ctx->gpumem)
+                gpu_free(ctx->buf); 
+        else 
+                free(ctx->buf);
 
-	if (ctx->gpu_id >= 0)
-		gpu_finalize();
+        if (ctx->gpu_id >= 0)
+                gpu_finalize();
 
-	free(ctx);
+        free(ctx);
 
-	return 0;
+        return 0;
 }
 
 static int block_server_stream(struct pingpong_context *ctx)
@@ -461,16 +461,16 @@ static int unblock_server_stream(struct pingpong_context *ctx)
         usleep(100);
         int ret = cuStreamQuery(gpu_stream_server);
         switch (ret) {
-        case CUDA_ERROR_NOT_READY:
-                break;
-        case CUDA_SUCCESS:
-                gpu_err("unexpected idle stream\n");
-                retcode = EINVAL;
-                break;
-        default:
-                gpu_err("unexpected error %d in stream query\n", ret);
-                retcode = EINVAL;
-                break;
+                case CUDA_ERROR_NOT_READY:
+                        break;
+                case CUDA_SUCCESS:
+                        gpu_err("unexpected idle stream\n");
+                        retcode = EINVAL;
+                        break;
+                default:
+                        gpu_err("unexpected error %d in stream query\n", ret);
+                        retcode = EINVAL;
+                        break;
         }
         gds_atomic_set_dword((uint32_t *)ctx->rx_flag, 1);
         return 0;
@@ -478,102 +478,102 @@ static int unblock_server_stream(struct pingpong_context *ctx)
 
 static int pp_post_recv(struct pingpong_context *ctx, int n)
 {
-	struct ibv_sge list = {
-		.addr	= (uintptr_t) ctx->rxbuf,
-		.length = ctx->size + 40,
-		.lkey	= ctx->mr->lkey
-	};
-	struct ibv_recv_wr wr = {
-		.wr_id	    = PINGPONG_RECV_WRID,
-		.sg_list    = &list,
-		.num_sge    = 1,
-	};
-	struct ibv_recv_wr *bad_wr;
-	int i;
+        struct ibv_sge list = {
+                .addr	= (uintptr_t) ctx->rxbuf,
+                .length = ctx->size + 40,
+                .lkey	= ctx->mr->lkey
+        };
+        struct ibv_recv_wr wr = {
+                .wr_id	    = PINGPONG_RECV_WRID,
+                .sg_list    = &list,
+                .num_sge    = 1,
+        };
+        struct ibv_recv_wr *bad_wr;
+        int i;
         gpu_dbg("posting %d recvs\n", n);
-	for (i = 0; i < n; ++i)
-		if (ibv_post_recv(ctx->qp, &wr, &bad_wr))
-			break;
+        for (i = 0; i < n; ++i)
+                if (ibv_post_recv(ctx->qp, &wr, &bad_wr))
+                        break;
         gpu_dbg("posted %d recvs\n", i);
-	return i;
+        return i;
 }
 
 // will be needed when implementing the !peersync !use_desc_apis case
 static int pp_post_send(struct pingpong_context *ctx, uint32_t qpn)
 {
         int ret = 0;
-	struct ibv_sge list = {
-		.addr	= (uintptr_t) ctx->txbuf,
-		.length = ctx->size,
-		.lkey	= ctx->mr->lkey
-	};
-	gds_send_wr ewr = {
-		.wr_id	    = PINGPONG_SEND_WRID,
-		.sg_list    = &list,
-		.num_sge    = 1,
-		.opcode = IBV_WR_SEND,
-		.send_flags = IBV_SEND_SIGNALED,
-		.wr         = {
-			.ud = {
-				 .ah          = ctx->ah,
-				 .remote_qpn  = qpn,
-				 .remote_qkey = 0x11111111
-			 }
-		},
-	};
-	gds_send_wr *bad_ewr;
-	return gds_post_send(ctx->gds_qp, &ewr, &bad_ewr);
+        struct ibv_sge list = {
+                .addr	= (uintptr_t) ctx->txbuf,
+                .length = ctx->size,
+                .lkey	= ctx->mr->lkey
+        };
+        gds_send_wr ewr = {
+                .wr_id	    = PINGPONG_SEND_WRID,
+                .sg_list    = &list,
+                .num_sge    = 1,
+                .opcode = IBV_WR_SEND,
+                .send_flags = IBV_SEND_SIGNALED,
+                .wr         = {
+                        .ud = {
+                                .ah          = ctx->ah,
+                                .remote_qpn  = qpn,
+                                .remote_qkey = 0x11111111
+                        }
+                },
+        };
+        gds_send_wr *bad_ewr;
+        return gds_post_send(ctx->gds_qp, &ewr, &bad_ewr);
 }
 
 static int pp_post_gpu_send(struct pingpong_context *ctx, uint32_t qpn, CUstream *p_gpu_stream)
 {
         int ret = 0;
-	struct ibv_sge list = {
-		.addr	= (uintptr_t) ctx->txbuf,
-		.length = ctx->size,
-		.lkey	= ctx->mr->lkey
-	};
-	gds_send_wr ewr = {
-		.wr_id	    = PINGPONG_SEND_WRID,
-		.sg_list    = &list,
-		.num_sge    = 1,
-		.opcode = IBV_WR_SEND,
-		.send_flags = IBV_SEND_SIGNALED,
-		.wr         = {
-			.ud = {
-				 .ah          = ctx->ah,
-				 .remote_qpn  = qpn,
-				 .remote_qkey = 0x11111111
-			 }
-		},
-	};
-	gds_send_wr *bad_ewr;
-	return gds_stream_queue_send(*p_gpu_stream, ctx->gds_qp, &ewr, &bad_ewr);
+        struct ibv_sge list = {
+                .addr	= (uintptr_t) ctx->txbuf,
+                .length = ctx->size,
+                .lkey	= ctx->mr->lkey
+        };
+        gds_send_wr ewr = {
+                .wr_id	    = PINGPONG_SEND_WRID,
+                .sg_list    = &list,
+                .num_sge    = 1,
+                .opcode = IBV_WR_SEND,
+                .send_flags = IBV_SEND_SIGNALED,
+                .wr         = {
+                        .ud = {
+                                .ah          = ctx->ah,
+                                .remote_qpn  = qpn,
+                                .remote_qkey = 0x11111111
+                        }
+                },
+        };
+        gds_send_wr *bad_ewr;
+        return gds_stream_queue_send(*p_gpu_stream, ctx->gds_qp, &ewr, &bad_ewr);
 }
 
 static int pp_prepare_gpu_send(struct pingpong_context *ctx, uint32_t qpn, gds_send_request_t *req)
 {
         int ret = 0;
-	struct ibv_sge list = {
-		.addr	= (uintptr_t) ctx->txbuf,
-		.length = ctx->size,
-		.lkey	= ctx->mr->lkey
-	};
-	gds_send_wr ewr = {
-		.wr_id	    = PINGPONG_SEND_WRID,
-		.sg_list    = &list,
-		.num_sge    = 1,
-		.opcode = IBV_WR_SEND,
-		.send_flags = IBV_SEND_SIGNALED,
-		.wr         = {
-			.ud = {
-				 .ah          = ctx->ah,
-				 .remote_qpn  = qpn,
-				 .remote_qkey = 0x11111111
-			 }
-		},
-	};
-	gds_send_wr *bad_ewr;
+        struct ibv_sge list = {
+                .addr	= (uintptr_t) ctx->txbuf,
+                .length = ctx->size,
+                .lkey	= ctx->mr->lkey
+        };
+        gds_send_wr ewr = {
+                .wr_id	    = PINGPONG_SEND_WRID,
+                .sg_list    = &list,
+                .num_sge    = 1,
+                .opcode = IBV_WR_SEND,
+                .send_flags = IBV_SEND_SIGNALED,
+                .wr         = {
+                        .ud = {
+                                .ah          = ctx->ah,
+                                .remote_qpn  = qpn,
+                                .remote_qkey = 0x11111111
+                        }
+                },
+        };
+        gds_send_wr *bad_ewr;
         //printf("gpu_post_send_on_stream\n");
         return gds_prepare_send(ctx->gds_qp, &ewr, &bad_ewr, req);
 }
@@ -611,7 +611,7 @@ out:
 static int pp_post_work(struct pingpong_context *ctx, int n_posts, int rcnt, uint32_t qpn, int is_client)
 {
         int retcode = 0;
-	int i, ret = 0;
+        int i, ret = 0;
         int posted_recv = 0;
 
         gpu_dbg("n_posts=%d rcnt=%d is_client=%d\n", n_posts, rcnt, is_client);
@@ -625,7 +625,7 @@ static int pp_post_work(struct pingpong_context *ctx, int n_posts, int rcnt, uin
         posted_recv = pp_post_recv(ctx, n_posts);
         if (posted_recv < 0) {
                 fprintf(stderr,"ERROR: can't post recv (%d) n_posts=%d is_client=%d\n", 
-                        posted_recv, n_posts, is_client);
+                                posted_recv, n_posts, is_client);
                 exit(EXIT_FAILURE);
                 return 0;
         } else if (posted_recv != n_posts) {
@@ -634,16 +634,16 @@ static int pp_post_work(struct pingpong_context *ctx, int n_posts, int rcnt, uin
                         return 0;
         }
         NVTX_POP();
-        
+
         PROF(&prof, prof_idx++);
 
         NVTX_PUSH("post send+wait", 1);
-	for (i = 0; i < posted_recv; ++i) {
+        for (i = 0; i < posted_recv; ++i) {
                 if (ctx->use_desc_apis) {
                         work_desc_t *wdesc = calloc(1, sizeof(work_desc_t));
                         if (wdesc == NULL) {
-                            gpu_err("cannot calloc wdesc\n");
-                            exit(EXIT_FAILURE);
+                                gpu_err("cannot calloc wdesc\n");
+                                exit(EXIT_FAILURE);
                         }
 
                         int k = 0;
@@ -694,7 +694,7 @@ static int pp_post_work(struct pingpong_context *ctx, int n_posts, int rcnt, uin
                         ret = pp_post_gpu_send(ctx, qpn, &gpu_stream_server);
                         if (ret) {
                                 gpu_err("error %d in pp_post_gpu_send, posted_recv=%d posted_so_far=%d is_client=%d \n",
-                                        ret, posted_recv, i, is_client);
+                                                ret, posted_recv, i, is_client);
                                 retcode = -ret;
                                 break;
                         }
@@ -720,10 +720,10 @@ static int pp_post_work(struct pingpong_context *ctx, int n_posts, int rcnt, uin
                         retcode = -EINVAL;
                         break;
                 }
-		if (ctx->skip_kernel_launch) {
+                if (ctx->skip_kernel_launch) {
                         gpu_warn_once("NOT LAUNCHING ANY KERNEL AT ALL\n");
                 } else {
-			gpu_launch_kernel_on_stream(ctx->calc_size, ctx->peersync, gpu_stream_server);
+                        gpu_launch_kernel_on_stream(ctx->calc_size, ctx->peersync, gpu_stream_server);
                 }
 
         }
@@ -735,63 +735,63 @@ static int pp_post_work(struct pingpong_context *ctx, int n_posts, int rcnt, uin
         }
         NVTX_POP();
 
-	return retcode;
+        return retcode;
 }
 
 static void usage(const char *argv0)
 {
-	printf("Usage:\n");
-	printf("  %s            start a server and wait for connection\n", argv0);
-	printf("  %s <host>     connect to server at <host>\n", argv0);
-	printf("\n");
-	printf("Options:\n");
-	printf("  -p, --port=<port>      listen on/connect to port <port> (default 18515)\n");
-	printf("  -d, --ib-dev=<dev>     use IB device <dev> (default first device found)\n");
-	printf("  -i, --ib-port=<port>   use port <port> of IB device (default 1)\n");
-	printf("  -s, --size=<size>      size of message to exchange (default 1024)\n");
-	printf("  -r, --rx-depth=<dep>   number of receives to post at a time (default 500)\n");
-	printf("  -n, --iters=<iters>    number of exchanges (default 1000)\n");
-	printf("  -e, --events           sleep on CQ events (default poll)\n");
-	printf("  -g, --gid-idx=<gid index> local port gid index\n");
-	printf("  -S, --gpu-calc-size=<size>  size of GPU compute buffer (default 128KB)\n");
-	printf("  -G, --gpu-id           use specified GPU (default 0)\n");
-	printf("  -B, --batch-length=<n> max batch length (default 20)\n");
-	printf("  -P, --peersync            disable GPUDirect PeerSync support (default enabled)\n");
-	printf("  -C, --peersync-gpu-cq     enable GPUDirect PeerSync GPU CQ support (default disabled)\n");
-	printf("  -D, --peersync-gpu-dbrec  enable QP DBREC on GPU memory (default disabled)\n");
-	printf("  -U, --peersync-desc-apis  use batched descriptor APIs (default disabled)\n");
-	printf("  -Q, --consume-rx-cqe      enable GPU consumes RX CQE support (default disabled)\n");
-	printf("  -M, --gpu-sched-mode      set CUDA context sched mode, default (A)UTO, (S)PIN, (Y)IELD, (B)LOCKING\n");
-	printf("  -E, --gpu-mem             allocate GPU intead of CPU memory buffers\n");
-	printf("  -K, --skip-kernel-launch  no GPU kernel computations, only communications\n");
-	printf("  -L, --hide-cpu-launch-latency try to prelaunch work on blocked stream then unblock\n");
+        printf("Usage:\n");
+        printf("  %s            start a server and wait for connection\n", argv0);
+        printf("  %s <host>     connect to server at <host>\n", argv0);
+        printf("\n");
+        printf("Options:\n");
+        printf("  -p, --port=<port>      listen on/connect to port <port> (default 18515)\n");
+        printf("  -d, --ib-dev=<dev>     use IB device <dev> (default first device found)\n");
+        printf("  -i, --ib-port=<port>   use port <port> of IB device (default 1)\n");
+        printf("  -s, --size=<size>      size of message to exchange (default 1024)\n");
+        printf("  -r, --rx-depth=<dep>   number of receives to post at a time (default 500)\n");
+        printf("  -n, --iters=<iters>    number of exchanges (default 1000)\n");
+        printf("  -e, --events           sleep on CQ events (default poll)\n");
+        printf("  -g, --gid-idx=<gid index> local port gid index\n");
+        printf("  -S, --gpu-calc-size=<size>  size of GPU compute buffer (default 128KB)\n");
+        printf("  -G, --gpu-id           use specified GPU (default 0)\n");
+        printf("  -B, --batch-length=<n> max batch length (default 20)\n");
+        printf("  -P, --peersync            disable GPUDirect PeerSync support (default enabled)\n");
+        printf("  -C, --peersync-gpu-cq     enable GPUDirect PeerSync GPU CQ support (default disabled)\n");
+        printf("  -D, --peersync-gpu-dbrec  enable QP DBREC on GPU memory (default disabled)\n");
+        printf("  -U, --peersync-desc-apis  use batched descriptor APIs (default disabled)\n");
+        printf("  -Q, --consume-rx-cqe      enable GPU consumes RX CQE support (default disabled)\n");
+        printf("  -M, --gpu-sched-mode      set CUDA context sched mode, default (A)UTO, (S)PIN, (Y)IELD, (B)LOCKING\n");
+        printf("  -E, --gpu-mem             allocate GPU intead of CPU memory buffers\n");
+        printf("  -K, --skip-kernel-launch  no GPU kernel computations, only communications\n");
+        printf("  -L, --hide-cpu-launch-latency try to prelaunch work on blocked stream then unblock\n");
 }
 
 int main(int argc, char *argv[])
 {
-	struct ibv_device      **dev_list;
-	struct ibv_device	*ib_dev;
-	struct pingpong_context *ctx;
-	struct pingpong_dest     my_dest;
-	struct pingpong_dest    *rem_dest;
-	struct timeval           rstart, start, end;
-	const char              *ib_devname = NULL;
-	char                    *servername = NULL;
-	int                      port = 18515;
-	int                      ib_port = 1;
-	int                      size = 1024;
-	int                      calc_size = 128*1024;
-	int                      rx_depth = 2*512;
-	int                      iters = 1000;
-	int                      use_event = 0;
-	int                      routs;
+        struct ibv_device      **dev_list;
+        struct ibv_device	*ib_dev;
+        struct pingpong_context *ctx;
+        struct pingpong_dest     my_dest;
+        struct pingpong_dest    *rem_dest;
+        struct timeval           rstart, start, end;
+        const char              *ib_devname = NULL;
+        char                    *servername = NULL;
+        int                      port = 18515;
+        int                      ib_port = 1;
+        int                      size = 1024;
+        int                      calc_size = 128*1024;
+        int                      rx_depth = 2*512;
+        int                      iters = 1000;
+        int                      use_event = 0;
+        int                      routs;
         int                      nposted;
-	int                      rcnt, scnt;
-	int                      num_cq_events = 0;
-	int                      sl = 0;
-	int			 gidx = -1;
-	char			 gid[INET6_ADDRSTRLEN];
-	int                      gpu_id = 0;
+        int                      rcnt, scnt;
+        int                      num_cq_events = 0;
+        int                      sl = 0;
+        int			 gidx = -1;
+        char			 gid[INET6_ADDRSTRLEN];
+        int                      gpu_id = 0;
         int                      peersync = 1;
         int                      peersync_gpu_cq = 0;
         int                      peersync_gpu_dbrec = 0;
@@ -820,171 +820,171 @@ int main(int argc, char *argv[])
                 exit(EXIT_FAILURE);
         }
 
-	srand48(getpid() * time(NULL));
+        srand48(getpid() * time(NULL));
 
-	while (1) {
-		int c;
+        while (1) {
+                int c;
 
-		static struct option long_options[] = {
-			{ .name = "port",     .has_arg = 1, .val = 'p' },
-			{ .name = "ib-dev",   .has_arg = 1, .val = 'd' },
-			{ .name = "ib-port",  .has_arg = 1, .val = 'i' },
-			{ .name = "size",     .has_arg = 1, .val = 's' },
-			{ .name = "rx-depth", .has_arg = 1, .val = 'r' },
-			{ .name = "iters",    .has_arg = 1, .val = 'n' },
-			{ .name = "sl",       .has_arg = 1, .val = 'l' },
-			{ .name = "events",   .has_arg = 0, .val = 'e' },
-			{ .name = "gid-idx",  .has_arg = 1, .val = 'g' },
-			{ .name = "gpu-id",          .has_arg = 1, .val = 'G' },
-			{ .name = "peersync",        .has_arg = 0, .val = 'P' },
-			{ .name = "peersync-gpu-cq", .has_arg = 0, .val = 'C' },
-			{ .name = "peersync-gpu-dbrec", .has_arg = 1, .val = 'D' },
+                static struct option long_options[] = {
+                        { .name = "port",     .has_arg = 1, .val = 'p' },
+                        { .name = "ib-dev",   .has_arg = 1, .val = 'd' },
+                        { .name = "ib-port",  .has_arg = 1, .val = 'i' },
+                        { .name = "size",     .has_arg = 1, .val = 's' },
+                        { .name = "rx-depth", .has_arg = 1, .val = 'r' },
+                        { .name = "iters",    .has_arg = 1, .val = 'n' },
+                        { .name = "sl",       .has_arg = 1, .val = 'l' },
+                        { .name = "events",   .has_arg = 0, .val = 'e' },
+                        { .name = "gid-idx",  .has_arg = 1, .val = 'g' },
+                        { .name = "gpu-id",          .has_arg = 1, .val = 'G' },
+                        { .name = "peersync",        .has_arg = 0, .val = 'P' },
+                        { .name = "peersync-gpu-cq", .has_arg = 0, .val = 'C' },
+                        { .name = "peersync-gpu-dbrec", .has_arg = 1, .val = 'D' },
                         { .name = "peersync-desc-apis", .has_arg = 0, .val = 'U' },
-			{ .name = "gpu-calc-size",   .has_arg = 1, .val = 'S' },
-			{ .name = "batch-length",    .has_arg = 1, .val = 'B' },
-			{ .name = "consume-rx-cqe",  .has_arg = 0, .val = 'Q' },
-			{ .name = "gpu-sched-mode",  .has_arg = 1, .val = 'M' },
-			{ .name = "gpu-mem",         .has_arg = 0, .val = 'E' },
-			{ .name = "wait-key",        .has_arg = 1, .val = 'W' },
-			{ .name = "skip-kernel-launch", .has_arg = 0, .val = 'K' },
-			{ .name = "hide-cpu-launch-latency", .has_arg = 0, .val = 'L' },
-			{ 0 }
-		};
+                        { .name = "gpu-calc-size",   .has_arg = 1, .val = 'S' },
+                        { .name = "batch-length",    .has_arg = 1, .val = 'B' },
+                        { .name = "consume-rx-cqe",  .has_arg = 0, .val = 'Q' },
+                        { .name = "gpu-sched-mode",  .has_arg = 1, .val = 'M' },
+                        { .name = "gpu-mem",         .has_arg = 0, .val = 'E' },
+                        { .name = "wait-key",        .has_arg = 1, .val = 'W' },
+                        { .name = "skip-kernel-launch", .has_arg = 0, .val = 'K' },
+                        { .name = "hide-cpu-launch-latency", .has_arg = 0, .val = 'L' },
+                        { 0 }
+                };
 
-		c = getopt_long(argc, argv, "p:d:i:s:r:n:l:eg:G:S:B:PCDQM:W:EUKL", long_options, NULL);
-		if (c == -1)
-			break;
+                c = getopt_long(argc, argv, "p:d:i:s:r:n:l:eg:G:S:B:PCDQM:W:EUKL", long_options, NULL);
+                if (c == -1)
+                        break;
 
-		switch (c) {
-		case 'p':
-			port = strtol(optarg, NULL, 0);
-			if (port < 0 || port > 65535) {
-				usage(argv[0]);
-                                ret = 1;
-                                exit(EXIT_FAILURE);
-			}
-			break;
+                switch (c) {
+                        case 'p':
+                                port = strtol(optarg, NULL, 0);
+                                if (port < 0 || port > 65535) {
+                                        usage(argv[0]);
+                                        ret = 1;
+                                        exit(EXIT_FAILURE);
+                                }
+                                break;
 
-		case 'd':
-			ib_devname = strdupa(optarg);
-			break;
+                        case 'd':
+                                ib_devname = strdupa(optarg);
+                                break;
 
-		case 'i':
-			ib_port = strtol(optarg, NULL, 0);
-			if (ib_port < 0) {
-				usage(argv[0]);
-				ret = 1;
-                                exit(EXIT_FAILURE);
-			}
-			break;
+                        case 'i':
+                                ib_port = strtol(optarg, NULL, 0);
+                                if (ib_port < 0) {
+                                        usage(argv[0]);
+                                        ret = 1;
+                                        exit(EXIT_FAILURE);
+                                }
+                                break;
 
-		case 's':
-			size = strtol(optarg, NULL, 0);
-                        printf("INFO: message size=%d\n", size);
-			break;
+                        case 's':
+                                size = strtol(optarg, NULL, 0);
+                                printf("INFO: message size=%d\n", size);
+                                break;
 
-		case 'S':
-			calc_size = strtol(optarg, NULL, 0);
-                        printf("INFO: kernel calc size=%d\n", calc_size);
-			break;
+                        case 'S':
+                                calc_size = strtol(optarg, NULL, 0);
+                                printf("INFO: kernel calc size=%d\n", calc_size);
+                                break;
 
-		case 'r':
-			rx_depth = strtol(optarg, NULL, 0);
-			break;
+                        case 'r':
+                                rx_depth = strtol(optarg, NULL, 0);
+                                break;
 
-		case 'n':
-			iters = strtol(optarg, NULL, 0);
-			break;
+                        case 'n':
+                                iters = strtol(optarg, NULL, 0);
+                                break;
 
-		case 'l':
-			sl = strtol(optarg, NULL, 0);
-			break;
+                        case 'l':
+                                sl = strtol(optarg, NULL, 0);
+                                break;
 
-		case 'e':
-			++use_event;
-			break;
+                        case 'e':
+                                ++use_event;
+                                break;
 
-		case 'g':
-			gidx = strtol(optarg, NULL, 0);
-			break;
+                        case 'g':
+                                gidx = strtol(optarg, NULL, 0);
+                                break;
 
-		case 'G':
-			gpu_id = strtol(optarg, NULL, 0);
-                        printf("INFO: gpu id=%d\n", gpu_id);
-			break;
+                        case 'G':
+                                gpu_id = strtol(optarg, NULL, 0);
+                                printf("INFO: gpu id=%d\n", gpu_id);
+                                break;
 
-		case 'B':
-			max_batch_len = strtol(optarg, NULL, 0);
-                        printf("INFO: max_batch_len=%d\n", max_batch_len);
-			break;
+                        case 'B':
+                                max_batch_len = strtol(optarg, NULL, 0);
+                                printf("INFO: max_batch_len=%d\n", max_batch_len);
+                                break;
 
-		case 'P':
-			peersync = !peersync;
-                        printf("INFO: switching PeerSync %s\n", peersync?"ON":"OFF");
-                        if (!peersync) {
-                                printf("WARNING: PeerSync OFF is approximated using CUDA stream callbacks\n");
-                        }
-			break;
+                        case 'P':
+                                peersync = !peersync;
+                                printf("INFO: switching PeerSync %s\n", peersync?"ON":"OFF");
+                                if (!peersync) {
+                                        printf("WARNING: PeerSync OFF is approximated using CUDA stream callbacks\n");
+                                }
+                                break;
 
-		case 'Q':
-			consume_rx_cqe = !consume_rx_cqe;
-                        printf("INFO: switching consume_rx_cqe %s\n", consume_rx_cqe?"ON":"OFF");
-			break;
+                        case 'Q':
+                                consume_rx_cqe = !consume_rx_cqe;
+                                printf("INFO: switching consume_rx_cqe %s\n", consume_rx_cqe?"ON":"OFF");
+                                break;
 
-		case 'C':
-			peersync_gpu_cq = !peersync_gpu_cq;
-                        printf("INFO: switching %s PeerSync GPU CQ\n", peersync_gpu_cq?"ON":"OFF");
-			break;
+                        case 'C':
+                                peersync_gpu_cq = !peersync_gpu_cq;
+                                printf("INFO: switching %s PeerSync GPU CQ\n", peersync_gpu_cq?"ON":"OFF");
+                                break;
 
-		case 'D':
-			peersync_gpu_dbrec= !peersync_gpu_dbrec;
-                        printf("INFO: switching %s PeerSync GPU QP DBREC\n", peersync_gpu_dbrec?"ON":"OFF");
-			break;
+                        case 'D':
+                                peersync_gpu_dbrec= !peersync_gpu_dbrec;
+                                printf("INFO: switching %s PeerSync GPU QP DBREC\n", peersync_gpu_dbrec?"ON":"OFF");
+                                break;
 
-		case 'M':
-                {
-                        char m = *optarg;
-                        printf("INFO: sched mode '%c'\n", m);
-                        switch (m) {
-                        case 'S': sched_mode = CU_CTX_SCHED_SPIN; break;
-                        case 'Y': sched_mode = CU_CTX_SCHED_YIELD; break;
-                        case 'B': sched_mode = CU_CTX_SCHED_BLOCKING_SYNC; break;
-                        case 'A': sched_mode = CU_CTX_SCHED_AUTO; break;
-                        default: printf("ERROR: unexpected value %c\n", m); exit(EXIT_FAILURE); break;
-                        }
+                        case 'M':
+                                {
+                                        char m = *optarg;
+                                        printf("INFO: sched mode '%c'\n", m);
+                                        switch (m) {
+                                                case 'S': sched_mode = CU_CTX_SCHED_SPIN; break;
+                                                case 'Y': sched_mode = CU_CTX_SCHED_YIELD; break;
+                                                case 'B': sched_mode = CU_CTX_SCHED_BLOCKING_SYNC; break;
+                                                case 'A': sched_mode = CU_CTX_SCHED_AUTO; break;
+                                                default: printf("ERROR: unexpected value %c\n", m); exit(EXIT_FAILURE); break;
+                                        }
+                                }
+                                break;
+
+                        case 'W':
+                                wait_key = strtol(optarg, NULL, 0);
+                                printf("INFO: wait_key=%d\n", wait_key);
+                                break;
+
+                        case 'E':
+                                use_gpumem = !use_gpumem;
+                                printf("INFO: use_gpumem=%d\n", use_gpumem);
+                                break;
+
+                        case 'U':
+                                use_desc_apis = 1;
+                                printf("INFO: use_desc_apis=%d\n", use_desc_apis);
+                                break;
+
+                        case 'K':
+                                skip_kernel_launch = 1;
+                                printf("INFO: skip_kernel_launch=%d\n", skip_kernel_launch);
+                                break;
+
+                        case 'L':
+                                hide_cpu_launch_latency = 1;
+                                printf("INFO: hide_cpu_launch_latency=%d\n", hide_cpu_launch_latency);
+                                break;
+
+                        default:
+                                usage(argv[0]);
+                                return 1;
                 }
-                break;
-
-                case 'W':
-                        wait_key = strtol(optarg, NULL, 0);
-                        printf("INFO: wait_key=%d\n", wait_key);
-                        break;
-
-                case 'E':
-                        use_gpumem = !use_gpumem;
-                        printf("INFO: use_gpumem=%d\n", use_gpumem);
-                        break;
-
-                case 'U':
-                        use_desc_apis = 1;
-                        printf("INFO: use_desc_apis=%d\n", use_desc_apis);
-                        break;
-
-                case 'K':
-                        skip_kernel_launch = 1;
-                        printf("INFO: skip_kernel_launch=%d\n", skip_kernel_launch);
-                        break;
-
-                case 'L':
-                        hide_cpu_launch_latency = 1;
-                        printf("INFO: hide_cpu_launch_latency=%d\n", hide_cpu_launch_latency);
-                        break;
-
-		default:
-			usage(argv[0]);
-			return 1;
-		}
-	}
+        }
 
         if (!peersync && !use_desc_apis) {
                 gpu_err("!peersync case only supported when using descriptor APIs, enabling them\n");
@@ -996,7 +996,7 @@ int main(int argc, char *argv[])
         char *hostnames[1] = {"localhost"};
 
         if (my_rank == 0) {
-		servername = hostnames[0];
+                servername = hostnames[0];
                 printf("[%d] pid=%d server:%s\n", my_rank, getpid(), servername);
         }
 
@@ -1006,13 +1006,13 @@ int main(int argc, char *argv[])
         //prof_init(&prof, 100, 100, "100ns", 25*4, 2, tags);
         prof_disable(&prof);
 
-	page_size = sysconf(_SC_PAGESIZE);
+        page_size = sysconf(_SC_PAGESIZE);
 
-	dev_list = ibv_get_device_list(NULL);
-	if (!dev_list) {
-		perror("Failed to get IB devices list");
-		return 1;
-	}
+        dev_list = ibv_get_device_list(NULL);
+        if (!dev_list) {
+                perror("Failed to get IB devices list");
+                return 1;
+        }
 
         if (!ib_devname) {
                 const char *value = getenv("USE_HCA"); 
@@ -1024,24 +1024,24 @@ int main(int argc, char *argv[])
                 printf("[%d] requested IB device: <%s>\n", my_rank, ib_devname);
         }
 
-	if (!ib_devname) {
+        if (!ib_devname) {
                 printf("picking 1st available device\n");
-		ib_dev = *dev_list;
-		if (!ib_dev) {
-			fprintf(stderr, "No IB devices found\n");
-			return 1;
-		}
-	} else {
-		int i;
-		for (i = 0; dev_list[i]; ++i)
-			if (!strcmp(ibv_get_device_name(dev_list[i]), ib_devname))
-				break;
-		ib_dev = dev_list[i];
-		if (!ib_dev) {
-			fprintf(stderr, "IB device %s not found\n", ib_devname);
-			return 1;
-		}
-	}
+                ib_dev = *dev_list;
+                if (!ib_dev) {
+                        fprintf(stderr, "No IB devices found\n");
+                        return 1;
+                }
+        } else {
+                int i;
+                for (i = 0; dev_list[i]; ++i)
+                        if (!strcmp(ibv_get_device_name(dev_list[i]), ib_devname))
+                                break;
+                ib_dev = dev_list[i];
+                if (!ib_dev) {
+                        fprintf(stderr, "IB device %s not found\n", ib_devname);
+                        return 1;
+                }
+        }
 
         {
                 const char *env = getenv("USE_GPU");
@@ -1051,54 +1051,54 @@ int main(int argc, char *argv[])
                 }
         }
         printf("use gpumem: %d\n", use_gpumem);
-	ctx = pp_init_ctx(ib_dev, size, calc_size, rx_depth, ib_port, 0, gpu_id, peersync, peersync_gpu_cq, peersync_gpu_dbrec, consume_rx_cqe, sched_mode, use_gpumem, use_desc_apis, skip_kernel_launch);
-	if (!ctx)
-		return 1;
+        ctx = pp_init_ctx(ib_dev, size, calc_size, rx_depth, ib_port, 0, gpu_id, peersync, peersync_gpu_cq, peersync_gpu_dbrec, consume_rx_cqe, sched_mode, use_gpumem, use_desc_apis, skip_kernel_launch);
+        if (!ctx)
+                return 1;
 
-	//pre-posting
-	int nrecv = pp_post_recv(ctx, max_batch_len);
-	if (nrecv < max_batch_len) {
-		fprintf(stderr, "Couldn't post receive (%d)\n", nrecv);
-		return 1;
-	}
+        //pre-posting
+        int nrecv = pp_post_recv(ctx, max_batch_len);
+        if (nrecv < max_batch_len) {
+                fprintf(stderr, "Couldn't post receive (%d)\n", nrecv);
+                return 1;
+        }
 
-	if (pp_get_port_info(ctx->context, ib_port, &ctx->portinfo)) {
-		fprintf(stderr, "Couldn't get port info\n");
-		return 1;
-	}
-	my_dest.lid = ctx->portinfo.lid;
+        if (pp_get_port_info(ctx->context, ib_port, &ctx->portinfo)) {
+                fprintf(stderr, "Couldn't get port info\n");
+                return 1;
+        }
+        my_dest.lid = ctx->portinfo.lid;
 
-	my_dest.qpn = ctx->qp->qp_num;
-	my_dest.psn = lrand48() & 0xffffff;
+        my_dest.qpn = ctx->qp->qp_num;
+        my_dest.psn = lrand48() & 0xffffff;
 
-	if (gidx >= 0) {
-		if (ibv_query_gid(ctx->context, ib_port, gidx, &my_dest.gid)) {
-			fprintf(stderr, "Could not get local gid for gid index "
-								"%d\n", gidx);
-			return 1;
-		}
-	} else
-		memset(&my_dest.gid, 0, sizeof my_dest.gid);
+        if (gidx >= 0) {
+                if (ibv_query_gid(ctx->context, ib_port, gidx, &my_dest.gid)) {
+                        fprintf(stderr, "Could not get local gid for gid index "
+                                        "%d\n", gidx);
+                        return 1;
+                }
+        } else
+                memset(&my_dest.gid, 0, sizeof my_dest.gid);
 
-	inet_ntop(AF_INET6, &my_dest.gid, gid, sizeof gid);
-	printf("  local address:  LID 0x%04x, QPN 0x%06x, PSN 0x%06x: GID %s\n",
-	       my_dest.lid, my_dest.qpn, my_dest.psn, gid);
-	
+        inet_ntop(AF_INET6, &my_dest.gid, gid, sizeof gid);
+        printf("  local address:  LID 0x%04x, QPN 0x%06x, PSN 0x%06x: GID %s\n",
+                        my_dest.lid, my_dest.qpn, my_dest.psn, gid);
+
         rem_dest = pp_client_exch_dest(servername, port, &my_dest);
 
-	if (!rem_dest) {
+        if (!rem_dest) {
                 fprintf(stderr, "Could not exchange destination\n");
-		ret = 1;
+                ret = 1;
                 goto out;
         }
 
-	inet_ntop(AF_INET6, &rem_dest->gid, gid, sizeof gid);
-	printf("  remote address: LID 0x%04x, QPN 0x%06x, PSN 0x%06x, GID %s\n",
-	       rem_dest->lid, rem_dest->qpn, rem_dest->psn, gid);
+        inet_ntop(AF_INET6, &rem_dest->gid, gid, sizeof gid);
+        printf("  remote address: LID 0x%04x, QPN 0x%06x, PSN 0x%06x, GID %s\n",
+                        rem_dest->lid, rem_dest->qpn, rem_dest->psn, gid);
 
-	if (servername) {
-		if (pp_connect_ctx(ctx, ib_port, my_dest.psn, sl, rem_dest, gidx))
-			return 1;
+        if (servername) {
+                if (pp_connect_ctx(ctx, ib_port, my_dest.psn, sl, rem_dest, gidx))
+                        return 1;
                 //sleep(1);
         }
 
@@ -1107,17 +1107,17 @@ int main(int argc, char *argv[])
                 block_server_stream(ctx);
         }
 
-	if (gettimeofday(&start, NULL)) {
-		perror("gettimeofday");
-		ret = 1;
+        if (gettimeofday(&start, NULL)) {
+                perror("gettimeofday");
+                ret = 1;
                 goto out;
-	}
+        }
 
         //printf("sleeping 10s\n");
         //sleep(10);
 
         // for performance reasons, multiple batches back-to-back are posted here
-	rcnt = scnt = 0;
+        rcnt = scnt = 0;
         nposted = 0;
         routs = 0;
         const int n_batches = 3;
@@ -1154,21 +1154,21 @@ int main(int argc, char *argv[])
                 printf("[%d] batch %d: posted %d sequences\n", my_rank, batch, n_posted);
         }
 
-	ctx->pending = PINGPONG_RECV_WRID;
+        ctx->pending = PINGPONG_RECV_WRID;
 
         float pre_post_us = 0;
 
-	if (gettimeofday(&end, NULL)) {
-		perror("gettimeofday");
-		ret = 1;
+        if (gettimeofday(&end, NULL)) {
+                perror("gettimeofday");
+                ret = 1;
                 goto out;
-	}
-	{
-		float usec = (end.tv_sec - start.tv_sec) * 1000000 +
-			(end.tv_usec - start.tv_usec);
-		printf("pre-posting took %.2f usec\n", usec);
+        }
+        {
+                float usec = (end.tv_sec - start.tv_sec) * 1000000 +
+                        (end.tv_usec - start.tv_usec);
+                printf("pre-posting took %.2f usec\n", usec);
                 pre_post_us = usec;
-	}
+        }
 
         if (hide_cpu_launch_latency) {
                 printf("ignoring pre-posting time and unblocking the stream\n");
@@ -1189,15 +1189,15 @@ int main(int argc, char *argv[])
                 fflush(stdout);
         }
 
-	if (gettimeofday(&start, NULL)) {
-		perror("gettimeofday");
-		return 1;
-	}
+        if (gettimeofday(&start, NULL)) {
+                perror("gettimeofday");
+                return 1;
+        }
         prof_enable(&prof);
         prof_idx = 0;
         int got_error = 0;
         int iter = 0;
-	while ((rcnt < iters && scnt < iters) && !got_error && !stream_cb_error) {
+        while ((rcnt < iters && scnt < iters) && !got_error && !stream_cb_error) {
                 ++iter;
                 PROF(&prof, prof_idx++);
 
@@ -1233,19 +1233,19 @@ int main(int argc, char *argv[])
                         for (i = 0; i < ne; ++i) {
                                 if (wc[i].status != IBV_WC_SUCCESS) {
                                         fprintf(stderr, "Failed status %s (%d) for wr_id %d\n",
-                                                ibv_wc_status_str(wc[i].status),
-                                                wc[i].status, (int) wc[i].wr_id);
+                                                        ibv_wc_status_str(wc[i].status),
+                                                        wc[i].status, (int) wc[i].wr_id);
                                         return 1;
                                 }
 
                                 switch ((int) wc[i].wr_id) {
-                                case PINGPONG_RECV_WRID:
-                                        ++rcnt;
-                                        break;
-                                default:
-                                        fprintf(stderr, "Completion for unknown wr_id %d\n",
-                                                (int) wc[i].wr_id);
-                                        return 1;
+                                        case PINGPONG_RECV_WRID:
+                                                ++rcnt;
+                                                break;
+                                        default:
+                                                fprintf(stderr, "Completion for unknown wr_id %d\n",
+                                                                (int) wc[i].wr_id);
+                                                return 1;
                                 }
                         }
                 } else {
@@ -1268,20 +1268,20 @@ int main(int argc, char *argv[])
                         for (i = 0; i < ne; ++i) {
                                 if (wc[i].status != IBV_WC_SUCCESS) {
                                         fprintf(stderr, "Failed status %s (%d) for wr_id %d\n",
-                                                ibv_wc_status_str(wc[i].status),
-                                                wc[i].status, (int) wc[i].wr_id);
+                                                        ibv_wc_status_str(wc[i].status),
+                                                        wc[i].status, (int) wc[i].wr_id);
                                         return 1;
                                 }
 
                                 switch ((int) wc[i].wr_id) {
-                                case PINGPONG_SEND_WRID:
-                                        ++scnt;
-                                        break;
-                                default:
-                                        fprintf(stderr, "Completion for unknown wr_id %d\n",
-                                                (int) wc[i].wr_id);
-                                        ret = 1;
-                                        goto out;
+                                        case PINGPONG_SEND_WRID:
+                                                ++scnt;
+                                                break;
+                                        default:
+                                                fprintf(stderr, "Completion for unknown wr_id %d\n",
+                                                                (int) wc[i].wr_id);
+                                                ret = 1;
+                                                goto out;
                                 }
                         }
                 }
@@ -1318,8 +1318,8 @@ int main(int argc, char *argv[])
                 }
                 //usleep(10);
                 PROF(&prof, prof_idx++);
-		prof_update(&prof);
-		prof_idx = 0;
+                prof_update(&prof);
+                prof_idx = 0;
 
                 //fprintf(stdout, "%d %d\n", rcnt, scnt); fflush(stdout);
 
@@ -1338,23 +1338,23 @@ int main(int argc, char *argv[])
                                 c = getchar();
                         }
                 }
-	}
+        }
 
-	if (gettimeofday(&end, NULL)) {
-		perror("gettimeofday");
-		ret = 1;
-	}
+        if (gettimeofday(&end, NULL)) {
+                perror("gettimeofday");
+                ret = 1;
+        }
 
-	{
-		float usec = (end.tv_sec - start.tv_sec) * 1000000 +
-			(end.tv_usec - start.tv_usec) + pre_post_us;
-		long long bytes = (long long) size * iters * 2;
+        {
+                float usec = (end.tv_sec - start.tv_sec) * 1000000 +
+                        (end.tv_usec - start.tv_usec) + pre_post_us;
+                long long bytes = (long long) size * iters * 2;
 
-		printf("[%d] %lld bytes in %.2f seconds = %.2f Mbit/sec\n",
-		       my_rank, bytes, usec / 1000000., bytes * 8. / usec);
-		printf("[%d] %d iters in %.2f seconds = %.2f usec/iter\n",
-		       my_rank, iters, usec / 1000000., usec / iters);
-	}
+                printf("[%d] %lld bytes in %.2f seconds = %.2f Mbit/sec\n",
+                                my_rank, bytes, usec / 1000000., bytes * 8. / usec);
+                printf("[%d] %d iters in %.2f seconds = %.2f usec/iter\n",
+                                my_rank, iters, usec / 1000000., usec / iters);
+        }
 
         if (prof_enabled(&prof)) {
                 printf("dumping prof\n");
@@ -1362,21 +1362,21 @@ int main(int argc, char *argv[])
         }
         prof_destroy(&prof);
 
-	//ibv_ack_cq_events(ctx->cq, num_cq_events);
-	
+        //ibv_ack_cq_events(ctx->cq, num_cq_events);
 
-	return 0;
+
+        return 0;
 
 out:
 
-	if (pp_close_ctx(ctx))
-		ret = 1;
+        if (pp_close_ctx(ctx))
+                ret = 1;
 
-	ibv_free_device_list(dev_list);
-	free(rem_dest);
+        ibv_free_device_list(dev_list);
+        free(rem_dest);
 
 
-	return ret;
+        return ret;
 }
 
 /*

--- a/tests/gds_kernel_loopback_latency.c
+++ b/tests/gds_kernel_loopback_latency.c
@@ -654,7 +654,7 @@ static int pp_post_work(struct pingpong_context *ctx, int n_posts, int rcnt, uin
                         }
                         assert(k < N_WORK_DESCS);
                         wdesc->descs[k].tag = GDS_TAG_SEND;
-                        wdesc->descs[k].send = wdesc->send_rq;
+                        wdesc->descs[k].send = &wdesc->send_rq;
                         ++k;
 
                         ret = gds_prepare_wait_cq(&ctx->gds_qp->send_cq, &wdesc->wait_tx_rq, 0);
@@ -664,7 +664,7 @@ static int pp_post_work(struct pingpong_context *ctx, int n_posts, int rcnt, uin
                         }
                         assert(k < N_WORK_DESCS);
                         wdesc->descs[k].tag = GDS_TAG_WAIT;
-                        wdesc->descs[k].wait = wdesc->wait_tx_rq;
+                        wdesc->descs[k].wait = &wdesc->wait_tx_rq;
                         ++k;
 
                         ret = gds_prepare_wait_cq(&ctx->gds_qp->recv_cq, &wdesc->wait_rx_rq, 0);
@@ -674,7 +674,7 @@ static int pp_post_work(struct pingpong_context *ctx, int n_posts, int rcnt, uin
                         }
                         assert(k < N_WORK_DESCS);
                         wdesc->descs[k].tag = GDS_TAG_WAIT;
-                        wdesc->descs[k].wait = wdesc->wait_rx_rq;
+                        wdesc->descs[k].wait = &wdesc->wait_rx_rq;
                         ++k;
 
                         if (ctx->peersync) {

--- a/tests/gds_kernel_loopback_latency.c
+++ b/tests/gds_kernel_loopback_latency.c
@@ -579,57 +579,12 @@ static int pp_prepare_gpu_send(struct pingpong_context *ctx, uint32_t qpn, gds_s
 }
 
 typedef struct work_desc {
-        gds_send_request_t *send_rq;
-        gds_wait_request_t *wait_tx_rq;
-        gds_wait_request_t *wait_rx_rq;
+        gds_send_request_t send_rq;
+        gds_wait_request_t wait_tx_rq;
+        gds_wait_request_t wait_rx_rq;
 #define N_WORK_DESCS 3
         gds_descriptor_t descs[N_WORK_DESCS];
 } work_desc_t;
-
-static void free_work_desc(work_desc_t *wdesc)
-{
-    if (!wdesc)
-        return;
-
-    if (wdesc->send_rq)
-        gds_free_send_request(wdesc->send_rq);
-
-    if (wdesc->wait_tx_rq)
-        gds_free_wait_request(wdesc->wait_tx_rq);
-
-    if (wdesc->wait_rx_rq)
-        gds_free_wait_request(wdesc->wait_rx_rq);
-
-    free(wdesc);
-}
-
-static int alloc_work_desc(work_desc_t **wdesc)
-{
-    *wdesc = (work_desc_t *)calloc(1, sizeof(work_desc_t));
-    if (*wdesc == NULL)
-        goto err;
-
-    if (gds_alloc_send_request(&(*wdesc)->send_rq, 1) != 0) {
-        gpu_err("cannot alloc send_rq\n");
-        goto err;
-    }
-
-    if (gds_alloc_wait_request(&(*wdesc)->wait_tx_rq, 1) != 0) {
-        gpu_err("cannot alloc wait_tx_rq\n");
-        goto err;
-    }
-
-    if (gds_alloc_wait_request(&(*wdesc)->wait_rx_rq, 1) != 0) {
-        gpu_err("cannot alloc wait_rx_rq\n");
-        goto err;
-    }
-
-    return 0;
-
-err:
-    free_work_desc(*wdesc);
-    return -ENOMEM;
-}
 
 static void post_work_cb(CUstream hStream, CUresult status, void *userData)\
 {
@@ -649,7 +604,7 @@ static void post_work_cb(CUstream hStream, CUresult status, void *userData)\
                 stream_cb_error = 1;
         }
 out:
-        free_work_desc(wdesc);
+        free(wdesc);
         NVTX_POP();
 }
 
@@ -685,14 +640,14 @@ static int pp_post_work(struct pingpong_context *ctx, int n_posts, int rcnt, uin
         NVTX_PUSH("post send+wait", 1);
 	for (i = 0; i < posted_recv; ++i) {
                 if (ctx->use_desc_apis) {
-                        work_desc_t *wdesc;
-                        if (alloc_work_desc(&wdesc) != 0) {
-                            gpu_err("cannot alloc work desc\n");
+                        work_desc_t *wdesc = calloc(1, sizeof(work_desc_t));
+                        if (wdesc == NULL) {
+                            gpu_err("cannot calloc wdesc\n");
                             exit(EXIT_FAILURE);
                         }
 
                         int k = 0;
-                        ret = pp_prepare_gpu_send(ctx, qpn, wdesc->send_rq);
+                        ret = pp_prepare_gpu_send(ctx, qpn, &wdesc->send_rq);
                         if (ret) {
                                 retcode = -ret;
                                 break;
@@ -702,7 +657,7 @@ static int pp_post_work(struct pingpong_context *ctx, int n_posts, int rcnt, uin
                         wdesc->descs[k].send = wdesc->send_rq;
                         ++k;
 
-                        ret = gds_prepare_wait_cq(&ctx->gds_qp->send_cq, wdesc->wait_tx_rq, 0);
+                        ret = gds_prepare_wait_cq(&ctx->gds_qp->send_cq, &wdesc->wait_tx_rq, 0);
                         if (ret) {
                                 retcode = -ret;
                                 break;
@@ -712,7 +667,7 @@ static int pp_post_work(struct pingpong_context *ctx, int n_posts, int rcnt, uin
                         wdesc->descs[k].wait = wdesc->wait_tx_rq;
                         ++k;
 
-                        ret = gds_prepare_wait_cq(&ctx->gds_qp->recv_cq, wdesc->wait_rx_rq, 0);
+                        ret = gds_prepare_wait_cq(&ctx->gds_qp->recv_cq, &wdesc->wait_rx_rq, 0);
                         if (ret) {
                                 retcode = -ret;
                                 break;
@@ -726,7 +681,7 @@ static int pp_post_work(struct pingpong_context *ctx, int n_posts, int rcnt, uin
                                 gpu_dbg("before gds_stream_post_descriptors\n");
                                 ret = gds_stream_post_descriptors(gpu_stream_server, k, wdesc->descs, 0);
                                 gpu_dbg("after gds_stream_post_descriptors\n");
-                                free_work_desc(wdesc);
+                                free(wdesc);
                                 if (ret) {
                                         retcode = -ret;
                                         break;

--- a/tests/gds_kernel_loopback_latency.c
+++ b/tests/gds_kernel_loopback_latency.c
@@ -579,12 +579,57 @@ static int pp_prepare_gpu_send(struct pingpong_context *ctx, uint32_t qpn, gds_s
 }
 
 typedef struct work_desc {
-        gds_send_request_t send_rq;
-        gds_wait_request_t wait_tx_rq;
-        gds_wait_request_t wait_rx_rq;
+        gds_send_request_t *send_rq;
+        gds_wait_request_t *wait_tx_rq;
+        gds_wait_request_t *wait_rx_rq;
 #define N_WORK_DESCS 3
         gds_descriptor_t descs[N_WORK_DESCS];
 } work_desc_t;
+
+static void free_work_desc(work_desc_t *wdesc)
+{
+    if (!wdesc)
+        return;
+
+    if (wdesc->send_rq)
+        gds_free_send_request(wdesc->send_rq);
+
+    if (wdesc->wait_tx_rq)
+        gds_free_wait_request(wdesc->wait_tx_rq);
+
+    if (wdesc->wait_rx_rq)
+        gds_free_wait_request(wdesc->wait_rx_rq);
+
+    free(wdesc);
+}
+
+static int alloc_work_desc(work_desc_t **wdesc)
+{
+    *wdesc = (work_desc_t *)calloc(1, sizeof(work_desc_t));
+    if (*wdesc == NULL)
+        goto err;
+
+    if (gds_alloc_send_request(&(*wdesc)->send_rq, 1) != 0) {
+        gpu_err("cannot alloc send_rq\n");
+        goto err;
+    }
+
+    if (gds_alloc_wait_request(&(*wdesc)->wait_tx_rq, 1) != 0) {
+        gpu_err("cannot alloc wait_tx_rq\n");
+        goto err;
+    }
+
+    if (gds_alloc_wait_request(&(*wdesc)->wait_rx_rq, 1) != 0) {
+        gpu_err("cannot alloc wait_rx_rq\n");
+        goto err;
+    }
+
+    return 0;
+
+err:
+    free_work_desc(*wdesc);
+    return -ENOMEM;
+}
 
 static void post_work_cb(CUstream hStream, CUresult status, void *userData)\
 {
@@ -604,7 +649,7 @@ static void post_work_cb(CUstream hStream, CUresult status, void *userData)\
                 stream_cb_error = 1;
         }
 out:
-        free(wdesc);
+        free_work_desc(wdesc);
         NVTX_POP();
 }
 
@@ -640,43 +685,48 @@ static int pp_post_work(struct pingpong_context *ctx, int n_posts, int rcnt, uin
         NVTX_PUSH("post send+wait", 1);
 	for (i = 0; i < posted_recv; ++i) {
                 if (ctx->use_desc_apis) {
-                        work_desc_t *wdesc = calloc(1, sizeof(*wdesc));
+                        work_desc_t *wdesc;
+                        if (alloc_work_desc(&wdesc) != 0) {
+                            gpu_err("cannot alloc work desc\n");
+                            exit(EXIT_FAILURE);
+                        }
+
                         int k = 0;
-                        ret = pp_prepare_gpu_send(ctx, qpn, &wdesc->send_rq);
+                        ret = pp_prepare_gpu_send(ctx, qpn, wdesc->send_rq);
                         if (ret) {
                                 retcode = -ret;
                                 break;
                         }
                         assert(k < N_WORK_DESCS);
                         wdesc->descs[k].tag = GDS_TAG_SEND;
-                        wdesc->descs[k].send = &wdesc->send_rq;
+                        wdesc->descs[k].send = wdesc->send_rq;
                         ++k;
 
-                        ret = gds_prepare_wait_cq(&ctx->gds_qp->send_cq, &wdesc->wait_tx_rq, 0);
+                        ret = gds_prepare_wait_cq(&ctx->gds_qp->send_cq, wdesc->wait_tx_rq, 0);
                         if (ret) {
                                 retcode = -ret;
                                 break;
                         }
                         assert(k < N_WORK_DESCS);
                         wdesc->descs[k].tag = GDS_TAG_WAIT;
-                        wdesc->descs[k].wait = &wdesc->wait_tx_rq;
+                        wdesc->descs[k].wait = wdesc->wait_tx_rq;
                         ++k;
 
-                        ret = gds_prepare_wait_cq(&ctx->gds_qp->recv_cq, &wdesc->wait_rx_rq, 0);
+                        ret = gds_prepare_wait_cq(&ctx->gds_qp->recv_cq, wdesc->wait_rx_rq, 0);
                         if (ret) {
                                 retcode = -ret;
                                 break;
                         }
                         assert(k < N_WORK_DESCS);
                         wdesc->descs[k].tag = GDS_TAG_WAIT;
-                        wdesc->descs[k].wait = &wdesc->wait_rx_rq;
+                        wdesc->descs[k].wait = wdesc->wait_rx_rq;
                         ++k;
 
                         if (ctx->peersync) {
                                 gpu_dbg("before gds_stream_post_descriptors\n");
                                 ret = gds_stream_post_descriptors(gpu_stream_server, k, wdesc->descs, 0);
                                 gpu_dbg("after gds_stream_post_descriptors\n");
-                                free(wdesc);
+                                free_work_desc(wdesc);
                                 if (ret) {
                                         retcode = -ret;
                                         break;

--- a/tests/gds_kernel_loopback_latency.c
+++ b/tests/gds_kernel_loopback_latency.c
@@ -94,7 +94,7 @@ struct pingpong_context {
 	struct ibv_cq		*tx_cq;
 	struct ibv_cq		*rx_cq;
 	struct ibv_qp		*qp;
-	struct gds_qp		*gds_qp;
+	gds_qp_t    		*gds_qp;
 	struct ibv_ah		*ah;
 	void			*buf;
 	char			*txbuf;

--- a/tests/gds_kernel_loopback_latency.c
+++ b/tests/gds_kernel_loopback_latency.c
@@ -511,8 +511,8 @@ static int pp_post_send(struct pingpong_context *ctx, uint32_t qpn)
 		.wr_id	    = PINGPONG_SEND_WRID,
 		.sg_list    = &list,
 		.num_sge    = 1,
-		.exp_opcode = IBV_EXP_WR_SEND,
-		.exp_send_flags = IBV_EXP_SEND_SIGNALED,
+		.opcode = IBV_WR_SEND,
+		.send_flags = IBV_SEND_SIGNALED,
 		.wr         = {
 			.ud = {
 				 .ah          = ctx->ah,
@@ -520,7 +520,6 @@ static int pp_post_send(struct pingpong_context *ctx, uint32_t qpn)
 				 .remote_qkey = 0x11111111
 			 }
 		},
-		.comp_mask = 0
 	};
 	gds_send_wr *bad_ewr;
 	return gds_post_send(ctx->gds_qp, &ewr, &bad_ewr);
@@ -538,8 +537,8 @@ static int pp_post_gpu_send(struct pingpong_context *ctx, uint32_t qpn, CUstream
 		.wr_id	    = PINGPONG_SEND_WRID,
 		.sg_list    = &list,
 		.num_sge    = 1,
-		.exp_opcode = IBV_EXP_WR_SEND,
-		.exp_send_flags = IBV_EXP_SEND_SIGNALED,
+		.opcode = IBV_WR_SEND,
+		.send_flags = IBV_SEND_SIGNALED,
 		.wr         = {
 			.ud = {
 				 .ah          = ctx->ah,
@@ -547,7 +546,6 @@ static int pp_post_gpu_send(struct pingpong_context *ctx, uint32_t qpn, CUstream
 				 .remote_qkey = 0x11111111
 			 }
 		},
-		.comp_mask = 0
 	};
 	gds_send_wr *bad_ewr;
 	return gds_stream_queue_send(*p_gpu_stream, ctx->gds_qp, &ewr, &bad_ewr);
@@ -565,8 +563,8 @@ static int pp_prepare_gpu_send(struct pingpong_context *ctx, uint32_t qpn, gds_s
 		.wr_id	    = PINGPONG_SEND_WRID,
 		.sg_list    = &list,
 		.num_sge    = 1,
-		.exp_opcode = IBV_EXP_WR_SEND,
-		.exp_send_flags = IBV_EXP_SEND_SIGNALED,
+		.opcode = IBV_WR_SEND,
+		.send_flags = IBV_SEND_SIGNALED,
 		.wr         = {
 			.ud = {
 				 .ah          = ctx->ah,
@@ -574,7 +572,6 @@ static int pp_prepare_gpu_send(struct pingpong_context *ctx, uint32_t qpn, gds_s
 				 .remote_qkey = 0x11111111
 			 }
 		},
-		.comp_mask = 0
 	};
 	gds_send_wr *bad_ewr;
         //printf("gpu_post_send_on_stream\n");

--- a/tests/gds_poll_lat.c
+++ b/tests/gds_poll_lat.c
@@ -24,12 +24,12 @@ int prof_idx = 0;
 int main(int argc, char *argv[])
 {
         int ret = 0;
-	int gpu_id = 0;
+        int gpu_id = 0;
         int num_iters = 1000;
         // this seems to minimize polling time
         int sleep_us = 10;
-	size_t page_size = sysconf(_SC_PAGESIZE);
-	size_t size = 1024*64;
+        size_t page_size = sysconf(_SC_PAGESIZE);
+        size_t size = 1024*64;
         int use_gpu_buf = 0;
         int use_flush = 0;
         int use_combined = 0;
@@ -49,52 +49,52 @@ int main(int argc, char *argv[])
                         break;
 
                 switch(c) {
-                case 'd':
-                        gpu_id = strtol(optarg, NULL, 0);
-                        break;
-                case 'W':
-                        wait_key = strtol(optarg, NULL, 0);
-                        break;
-                case 'p':
-                        n_bg_streams = strtol(optarg, NULL, 0);
-                        break;
-                case 'c':
-                        // merge poll and multiple pokes
-                        use_combined = 1;
-                        break;
-                case 'P':
-                        // multiple pokes
-                        n_pokes = strtol(optarg, NULL, 0);
-                        break;
-                case 'm':
-                        use_membar = 1;
-                        break;
-                case 'n':
-                        num_iters = strtol(optarg, NULL, 0);
-                        break;
-                case 's':
-                        sleep_us = strtol(optarg, NULL, 0);
-                        break;
-                case 'f':
-                        use_flush = 1;
-                        gpu_info("enabling flush\n");
-                        break;
-                case 'g':
-                        use_gpu_buf = 1;
-                        gpu_info("polling on GPU buffer\n");
-                        break;
-                case 'w':
-                        use_wrmem = 1;
-                        gpu_info("enabling use of WRITE_MEMORY\n");
-                        break;
-                case '?':
-                case 'h':
-                        printf(" %s [-n <iters>][-s <sleep us>][-p # bg streams][-P # pokes][ckhfgomW]\n", argv[0]);
-                        exit(EXIT_SUCCESS);
-                        break;
-                default:
-                        gpu_err("invalid option '%c'\n", c);
-                        exit(EXIT_FAILURE);
+                        case 'd':
+                                gpu_id = strtol(optarg, NULL, 0);
+                                break;
+                        case 'W':
+                                wait_key = strtol(optarg, NULL, 0);
+                                break;
+                        case 'p':
+                                n_bg_streams = strtol(optarg, NULL, 0);
+                                break;
+                        case 'c':
+                                // merge poll and multiple pokes
+                                use_combined = 1;
+                                break;
+                        case 'P':
+                                // multiple pokes
+                                n_pokes = strtol(optarg, NULL, 0);
+                                break;
+                        case 'm':
+                                use_membar = 1;
+                                break;
+                        case 'n':
+                                num_iters = strtol(optarg, NULL, 0);
+                                break;
+                        case 's':
+                                sleep_us = strtol(optarg, NULL, 0);
+                                break;
+                        case 'f':
+                                use_flush = 1;
+                                gpu_info("enabling flush\n");
+                                break;
+                        case 'g':
+                                use_gpu_buf = 1;
+                                gpu_info("polling on GPU buffer\n");
+                                break;
+                        case 'w':
+                                use_wrmem = 1;
+                                gpu_info("enabling use of WRITE_MEMORY\n");
+                                break;
+                        case '?':
+                        case 'h':
+                                printf(" %s [-n <iters>][-s <sleep us>][-p # bg streams][-P # pokes][ckhfgomW]\n", argv[0]);
+                                exit(EXIT_SUCCESS);
+                                break;
+                        default:
+                                gpu_err("invalid option '%c'\n", c);
+                                exit(EXIT_FAILURE);
                 }
         }
 
@@ -102,25 +102,25 @@ int main(int argc, char *argv[])
                 gpu_err("n_pokes must be 1 at least\n");
                 exit(EXIT_FAILURE);
         }
-        
+
         CUstream bg_streams[n_bg_streams];
         memset(bg_streams, 0, sizeof(bg_streams));
 
         //if (use_combined && use_pokes) {
         //        fprintf(stderr, "error, incompatible switches\n");
-	//	exit(EXIT_FAILURE);
+        //	exit(EXIT_FAILURE);
         //}
         const char *tags = "postpoll|que poke|   sleep|  set dw|pollpoke|str sync";
         if ( /*prof_init(&prof, 1000, 1000, "1ms", 50, 1, tags)*/
-                prof_init(&prof, 100, 100, "100ns", 25*4*2, 5, tags)) {
+                        prof_init(&prof, 100, 100, "100ns", 25*4*2, 5, tags)) {
                 gpu_err("error in prof_init init.\n");
-		exit(EXIT_FAILURE);
-	}
+                exit(EXIT_FAILURE);
+        }
 
-	if (gpu_init(gpu_id, CU_CTX_SCHED_AUTO)) {
-		gpu_err("error in GPU init.\n");
-		exit(EXIT_FAILURE);
-	}
+        if (gpu_init(gpu_id, CU_CTX_SCHED_AUTO)) {
+                gpu_err("error in GPU init.\n");
+                exit(EXIT_FAILURE);
+        }
 
         //CUCHECK(cuStreamCreate(&gpu_stream, 0));
 
@@ -184,7 +184,7 @@ int main(int argc, char *argv[])
         perf_start();
         gds_us_t delta_t = 0;
         int warmup = 5;
-	for (i = 0, value = 1; i < num_iters; ++i, ++value) {
+        for (i = 0, value = 1; i < num_iters; ++i, ++value) {
                 ASSERT(value <= INT_MAX);
                 uint32_t *h_ptr = (uint32_t*)h_buf + (i % (size/sizeof(uint32_t)));
                 uint32_t *d_ptr = (uint32_t*)d_buf + (i % (size/sizeof(uint32_t)));
@@ -197,7 +197,7 @@ int main(int argc, char *argv[])
                                 c = getchar();
                         }
                 }
-		PROF(&prof, prof_idx++);
+                PROF(&prof, prof_idx++);
 
                 assert(n_pokes < size/sizeof(uint32_t));
                 gds_descriptor_t descs[n_pokes+1];
@@ -219,18 +219,18 @@ int main(int argc, char *argv[])
                                 gpu_dbg("poke %d WRITE_VALUE32\n", k);
                                 descs[1+k].tag = GDS_TAG_WRITE_VALUE32;
                                 GDSCHECK(gds_prepare_write_value32(&descs[1+k].write32,
-                                                                   ptr,
-                                                                   0xd4d00000|(j<<8)|k,
-                                                                   dflags));
+                                                        ptr,
+                                                        0xd4d00000|(j<<8)|k,
+                                                        dflags));
                         } else {
                                 gpu_dbg("poke %d WRITE_MEMORY\n", k);
                                 descs[1+k].tag = GDS_TAG_WRITE_MEMORY;
                                 uint32_t word = 0xd4d00000|(j<<8)|k;
                                 GDSCHECK(gds_prepare_write_memory(&descs[1+k].writemem,
-                                                                  (uint8_t*)ptr,
-                                                                  (uint8_t*)&word,
-                                                                  sizeof(word),
-                                                                  dflags));
+                                                        (uint8_t*)ptr,
+                                                        (uint8_t*)&word,
+                                                        sizeof(word),
+                                                        dflags));
                         }
 
                         poke_hptrs[k] =  h_data  + off;
@@ -248,7 +248,7 @@ int main(int argc, char *argv[])
                         PROF(&prof, prof_idx++);
                         GDSCHECK(gds_stream_post_descriptors(gpu_stream, n_pokes, descs+1, 0));
                 }
-		PROF(&prof, prof_idx++);
+                PROF(&prof, prof_idx++);
 
                 if (use_gpu_buf) {
                         int c;
@@ -266,12 +266,12 @@ int main(int argc, char *argv[])
                         gpu_err("error, stream must NOT be idle at this point, iter:%d\n", i);
                         exit(EXIT_FAILURE);
                 }
-		PROF(&prof, prof_idx++);
+                PROF(&prof, prof_idx++);
                 // CPU writes to SYS/VIDMEM, triggering the GPU acquire, 
                 // which should trigger execution past the sema acquire
                 gpu_dbg("writing h_ptr=%p value=%08x\n", h_ptr, value);
-		gds_atomic_set_dword(h_ptr, value);
-		PROF(&prof, prof_idx++);
+                gds_atomic_set_dword(h_ptr, value);
+                PROF(&prof, prof_idx++);
                 // CPU polling on zero-copy SYSMEM
                 //if (use_pokes || use_combined)
                 //        ret = gpu_poll_pokes();
@@ -284,18 +284,18 @@ int main(int argc, char *argv[])
                         gpu_fail("error while polling on %zu poke\n", n_pokes-1);
                 }
                 gds_us_t end = gds_get_time_us();
-		PROF(&prof, prof_idx++);
+                PROF(&prof, prof_idx++);
                 // CUDA synchronize
-		//gpu_wait_kernel();
+                //gpu_wait_kernel();
                 CUCHECK(cuStreamSynchronize(gpu_stream));
-		PROF(&prof, prof_idx++);
-		prof_update(&prof);
-		prof_idx = 0;
-                
+                PROF(&prof, prof_idx++);
+                prof_update(&prof);
+                prof_idx = 0;
+
                 if (i > warmup) {
                         delta_t += end - start;
                 }
-	}
+        }
         gpu_info("test finished!\n");
 
         if (num_iters > warmup) {
@@ -327,7 +327,7 @@ err:
         GDSCHECK(ret = gds_free_mapped_memory(&desc_data));
 
 out:
-	gpu_finalize();
+        gpu_finalize();
         return ret;
 }
 

--- a/tests/gds_poll_lat.c
+++ b/tests/gds_poll_lat.c
@@ -11,7 +11,6 @@
 #include <assert.h>
 #include <limits.h>
 
-#include <infiniband/verbs_exp.h>
 #include <gdsync.h>
 #include <gdsync/tools.h>
 #include <gdrapi.h>

--- a/tests/gds_sanity.cpp
+++ b/tests/gds_sanity.cpp
@@ -14,7 +14,6 @@
 #include <cuda.h>
 #include <cuda_runtime_api.h>
 
-#include <infiniband/verbs_exp.h>
 #include <gdsync.h>
 #include <gdsync/tools.h>
 #include <gdsync/device.cuh>

--- a/tests/gds_sanity.cpp
+++ b/tests/gds_sanity.cpp
@@ -29,7 +29,7 @@ int poll_dword_geq(uint32_t *ptr, uint32_t payload, gds_us_t tm)
 {
         gds_us_t start = gds_get_time_us();
         int ret = 0;
-        while(1) {
+        while (1) {
                 uint32_t value = gds_atomic_read_dword(ptr);
                 gpu_dbg("val=%x\n", value);
                 if (value >= payload) {
@@ -67,50 +67,50 @@ int main(int argc, char *argv[])
                         break;
 
                 switch(c) {
-                case 'd':
-                        gpu_id = strtol(optarg, NULL, 0);
-                        break;
-                case 'm':
-                        use_membar = !use_membar;
-                        break;
-                case 'n':
-                        num_iters = strtol(optarg, NULL, 0);
-                        break;
-                case 'f':
-                        use_flush = 1;
-                        printf("INFO enabling flush\n");
-                        break;
-                case 'g':
-                        use_gpu_buf = 1;
-                        printf("INFO polling on GPU buffer\n");
-                        break;
-                case 'N':
-                        use_nor = 1;
-                        printf("INFO polling using NOR\n");
-                        break;
-                case 'h':
-                        printf("Usage:\n"
-                               " %s [options]\n"
-                               "Options:\n"
-                               " -d id  use gpu ordinal id\n"
-                               " -n n   iterate n times\n"
-                               " -f     issue a GPU RDMA flush following each poll\n"
-                               " -g     allocate all memory on GPU\n"
-                               " -m     issue memory barrier between signal and data stores\n"
-                               " -N     poll memory using NOR condition (requires Volta)\n"
-                               " -h     this help\n", argv[0]);
-                        exit(EXIT_SUCCESS);
-                        break;
-                default:
-                        printf("ERROR: invalid option\n");
-                        exit(EXIT_FAILURE);
+                        case 'd':
+                                gpu_id = strtol(optarg, NULL, 0);
+                                break;
+                        case 'm':
+                                use_membar = !use_membar;
+                                break;
+                        case 'n':
+                                num_iters = strtol(optarg, NULL, 0);
+                                break;
+                        case 'f':
+                                use_flush = 1;
+                                printf("INFO enabling flush\n");
+                                break;
+                        case 'g':
+                                use_gpu_buf = 1;
+                                printf("INFO polling on GPU buffer\n");
+                                break;
+                        case 'N':
+                                use_nor = 1;
+                                printf("INFO polling using NOR\n");
+                                break;
+                        case 'h':
+                                printf("Usage:\n"
+                                                " %s [options]\n"
+                                                "Options:\n"
+                                                " -d id  use gpu ordinal id\n"
+                                                " -n n   iterate n times\n"
+                                                " -f     issue a GPU RDMA flush following each poll\n"
+                                                " -g     allocate all memory on GPU\n"
+                                                " -m     issue memory barrier between signal and data stores\n"
+                                                " -N     poll memory using NOR condition (requires Volta)\n"
+                                                " -h     this help\n", argv[0]);
+                                exit(EXIT_SUCCESS);
+                                break;
+                        default:
+                                printf("ERROR: invalid option\n");
+                                exit(EXIT_FAILURE);
                 }
         }
 
-	if (gpu_init(gpu_id, CU_CTX_SCHED_AUTO)) {
-		fprintf(stderr, "error in GPU init.\n");
-		exit(EXIT_FAILURE);
-	}
+        if (gpu_init(gpu_id, CU_CTX_SCHED_AUTO)) {
+                fprintf(stderr, "error in GPU init.\n");
+                exit(EXIT_FAILURE);
+        }
 
         puts("");
         printf("number iterations %d\n", num_iters);
@@ -120,7 +120,7 @@ int main(int argc, char *argv[])
         printf("poll on %s buffer\n", use_gpu_buf?"GPU":"CPU");
         printf("write on %s buffer\n", use_gpu_buf?"GPU":"CPU");
         puts("");
-        
+
 
         int mem_type = use_gpu_buf ? GDS_MEMORY_GPU : GDS_MEMORY_HOST;
 
@@ -267,7 +267,7 @@ int main(int argc, char *argv[])
                                         ASSERT(gds_atomic_read_dword(h_signal) == (value-1));
                                 }
                                 ASSERT(gds_atomic_read_dword(h_done) == (value-1));
-                                
+
                                 gpu_dbg("%d:       dbg @%p:%08x\n", i, h_dbg, gds_atomic_read_dword(h_dbg));
                                 gpu_dbg("%d:       sig @%p:%08x\n", i, h_signal, gds_atomic_read_dword(h_signal));
                                 gpu_dbg("%d:      done @%p:%08x\n", i, h_done, gds_atomic_read_dword(h_done));
@@ -338,7 +338,7 @@ err:
                 gpu_fail("error (%d) while freeing mem\n", ret);
         }
 
-	gpu_finalize();
+        gpu_finalize();
 
         printf(">>> SUCCESS\n");
         return ret;

--- a/tests/gpu.cpp
+++ b/tests/gpu.cpp
@@ -71,52 +71,52 @@ int gpu_launch_void_kernel_on_stream(CUstream s);
 
 int gpu_init(int gpu_id, int sched_mode)
 {
-	int ret = 0;
+        int ret = 0;
 
-	CUCHECK(cuInit(0));
-	
-	int deviceCount = 0;
-	CUCHECK(cuDeviceGetCount(&deviceCount));
+        CUCHECK(cuInit(0));
 
-	// This function call returns 0 if there are no CUDA capable devices.
-	if (deviceCount == 0) {
-		gpu_err("There are no available device(s) that support CUDA\n");
-		ret = 1;
-		goto out;
-	} else {
-		gpu_dbg("There are %d devices supporting CUDA, picking N.%d\n", deviceCount, gpu_id);
+        int deviceCount = 0;
+        CUCHECK(cuDeviceGetCount(&deviceCount));
+
+        // This function call returns 0 if there are no CUDA capable devices.
+        if (deviceCount == 0) {
+                gpu_err("There are no available device(s) that support CUDA\n");
+                ret = 1;
+                goto out;
+        } else {
+                gpu_dbg("There are %d devices supporting CUDA, picking N.%d\n", deviceCount, gpu_id);
         }
         if (getenv("USE_GPU")) {
                 gpu_id = atoi(getenv("USE_GPU"));
                 gpu_info("overriding gpu_id with USE_GPU=%d\n", gpu_id);
         }
 
-	if (gpu_id >= deviceCount) {
-		gpu_err("ERROR: requested GPU gpu_id beyond available\n");
-		ret = 1;
-		goto out;
-	}
+        if (gpu_id >= deviceCount) {
+                gpu_err("ERROR: requested GPU gpu_id beyond available\n");
+                ret = 1;
+                goto out;
+        }
         gpu_blocking_sync_mode = (CU_CTX_SCHED_BLOCKING_SYNC == sched_mode) ? 1 : 0;
 
-	int i;
-	for (i=0; i<deviceCount; ++i) {
-		CUCHECK(cuDeviceGet(&gpu_device, i));
-		char name[128];
-		CUCHECK(cuDeviceGetName(name, sizeof(name), gpu_device));
-		int pciBusID, pciDeviceID;
-		cuDeviceGetAttribute(&pciBusID, CU_DEVICE_ATTRIBUTE_PCI_BUS_ID, gpu_device);
-		cuDeviceGetAttribute(&pciDeviceID, CU_DEVICE_ATTRIBUTE_PCI_DEVICE_ID, gpu_device);
-		//printf("  Device PCI Bus ID / PCI location ID:           %d / %d\n", pciBusID, pciDeviceID);
-		gpu_info("GPU id:%d dev:%d name:%s pci %d:%d\n", i, gpu_device, name, pciBusID, pciDeviceID);
-	}
+        int i;
+        for (i=0; i<deviceCount; ++i) {
+                CUCHECK(cuDeviceGet(&gpu_device, i));
+                char name[128];
+                CUCHECK(cuDeviceGetName(name, sizeof(name), gpu_device));
+                int pciBusID, pciDeviceID;
+                cuDeviceGetAttribute(&pciBusID, CU_DEVICE_ATTRIBUTE_PCI_BUS_ID, gpu_device);
+                cuDeviceGetAttribute(&pciDeviceID, CU_DEVICE_ATTRIBUTE_PCI_DEVICE_ID, gpu_device);
+                //printf("  Device PCI Bus ID / PCI location ID:           %d / %d\n", pciBusID, pciDeviceID);
+                gpu_info("GPU id:%d dev:%d name:%s pci %d:%d\n", i, gpu_device, name, pciBusID, pciDeviceID);
+        }
 
-	CUCHECK(cuDeviceGet(&gpu_device, gpu_id));
+        CUCHECK(cuDeviceGet(&gpu_device, gpu_id));
 
-	gpu_info("creating CUDA Primary Ctx on device:%d id:%d\n", gpu_device, gpu_id);
+        gpu_info("creating CUDA Primary Ctx on device:%d id:%d\n", gpu_device, gpu_id);
         CUCHECK(cuDevicePrimaryCtxRetain(&gpu_ctx, gpu_device));
 
-	gpu_dbg("making it the current CUDA Ctx\n");
-	CUCHECK(cuCtxSetCurrent(gpu_ctx));
+        gpu_dbg("making it the current CUDA Ctx\n");
+        CUCHECK(cuCtxSetCurrent(gpu_ctx));
 
         // TODO: add a check for canMapHost
 
@@ -126,11 +126,11 @@ int gpu_init(int gpu_id, int sched_mode)
         cuDeviceGetAttribute(&gpu_clock_rate, CU_DEVICE_ATTRIBUTE_CLOCK_RATE, gpu_device);
         gpu_dbg("clock rate:%d\n", gpu_clock_rate);
 
-	CUCHECK(cuStreamCreate(&gpu_stream, 0));
+        CUCHECK(cuStreamCreate(&gpu_stream, 0));
         gpu_dbg("created main test CUDA stream %p\n", gpu_stream);
-	CUCHECK(cuStreamCreate(&gpu_stream_server, 0));
+        CUCHECK(cuStreamCreate(&gpu_stream_server, 0));
         gpu_dbg("created stream server CUDA stream %p\n", gpu_stream_server);
-	CUCHECK(cuStreamCreate(&gpu_stream_client, 0));
+        CUCHECK(cuStreamCreate(&gpu_stream_client, 0));
         gpu_dbg("created stream client CUDA stream %p\n", gpu_stream_client);
 
         {
@@ -156,49 +156,49 @@ out:
                         CUCHECK(cuDevicePrimaryCtxRelease(gpu_device));
         }
 
-	return ret;
+        return ret;
 }
 
 int gpu_finalize()
 {
-	gpu_dbg("destroying current CUDA Ctx\n");
+        gpu_dbg("destroying current CUDA Ctx\n");
         CUCHECK(cuCtxSynchronize());
         int n;
         for (n=0; n<num_tracking_events; ++n)
                 CUCHECK(cuEventDestroy(gpu_tracking_event[n]));
-	CUCHECK(cuStreamDestroy(gpu_stream));
-	CUCHECK(cuStreamDestroy(gpu_stream_server));
-	CUCHECK(cuStreamDestroy(gpu_stream_client));
+        CUCHECK(cuStreamDestroy(gpu_stream));
+        CUCHECK(cuStreamDestroy(gpu_stream_server));
+        CUCHECK(cuStreamDestroy(gpu_stream_client));
         CUCHECK(cuDevicePrimaryCtxRelease(gpu_device));
 
-	return 0;
+        return 0;
 }
 
 void *gpu_malloc(size_t page_size, size_t min_size)
 {
-	size_t n_pages = (min_size + page_size - 1)/page_size;
-	size_t size = n_pages * page_size;
+        size_t n_pages = (min_size + page_size - 1)/page_size;
+        size_t size = n_pages * page_size;
 
-	gpu_dbg("cuMemAlloc() of a %lu bytes GPU buffer\n", size);
-	CUdeviceptr d_A;
-	CUCHECK(cuMemAlloc(&d_A, size));
-	CUCHECK(cuMemsetD8(d_A, 0, size));
+        gpu_dbg("cuMemAlloc() of a %lu bytes GPU buffer\n", size);
+        CUdeviceptr d_A;
+        CUCHECK(cuMemAlloc(&d_A, size));
+        CUCHECK(cuMemsetD8(d_A, 0, size));
 
-	gpu_dbg("allocated GPU buffer address at %016llx\n", d_A);
-	return (void*)d_A;
+        gpu_dbg("allocated GPU buffer address at %016llx\n", d_A);
+        return (void*)d_A;
 }
 
 int gpu_free(void *ptr)
 {
-	CUCHECK(cuMemFree((CUdeviceptr)ptr));
-	return 0;
+        CUCHECK(cuMemFree((CUdeviceptr)ptr));
+        return 0;
 }
 
 int gpu_memset(void *ptr, const unsigned char c, size_t size)
 {
-	gpu_dbg("poisoning GPU buffer, filled with '0x%02x' !!!\n", c);
-	CUCHECK(cuMemsetD8((CUdeviceptr)ptr, c, size));
-	return 0;
+        gpu_dbg("poisoning GPU buffer, filled with '0x%02x' !!!\n", c);
+        CUCHECK(cuMemsetD8((CUdeviceptr)ptr, c, size));
+        return 0;
 }
 
 int gpu_register_host_mem(void *ptr, size_t size)

--- a/tests/gpu.cpp
+++ b/tests/gpu.cpp
@@ -29,7 +29,6 @@
 #include <assert.h>
 
 #include <cuda_runtime_api.h>
-#include <infiniband/verbs_exp.h>
 
 #include "gdrapi.h"
 #include "gdsync.h"

--- a/tests/gpu.h
+++ b/tests/gpu.h
@@ -28,7 +28,6 @@
 #pragma once
 
 #include <cuda.h>
-#include <infiniband/verbs_exp.h>
 
 
 #ifdef USE_PROFILE

--- a/tests/gpu.h
+++ b/tests/gpu.h
@@ -42,18 +42,18 @@
 #ifdef USE_NVTX
 #include "nvToolsExt.h"
 #define NVTX_PUSH(name,cid) do { \
-	uint32_t colors[] = { 0x0000ff00, 0x000000ff, 0x00ffff00, 0x00ff00ff, 0x0000ffff, 0x00ff0000, 0x00ffffff }; \
-	int num_colors = sizeof(colors)/sizeof(uint32_t); \
-	int color_id = cid; \
-	color_id = color_id%num_colors;\
-	nvtxEventAttributes_t eventAttrib = {0}; \
-	eventAttrib.version = NVTX_VERSION; \
-	eventAttrib.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE; \
-	eventAttrib.colorType = NVTX_COLOR_ARGB; \
-	eventAttrib.color = colors[color_id]; \
-	eventAttrib.messageType = NVTX_MESSAGE_TYPE_ASCII; \
-	eventAttrib.message.ascii = name; \
-	nvtxRangePushEx(&eventAttrib); \
+        uint32_t colors[] = { 0x0000ff00, 0x000000ff, 0x00ffff00, 0x00ff00ff, 0x0000ffff, 0x00ff0000, 0x00ffffff }; \
+        int num_colors = sizeof(colors)/sizeof(uint32_t); \
+        int color_id = cid; \
+        color_id = color_id%num_colors;\
+        nvtxEventAttributes_t eventAttrib = {0}; \
+        eventAttrib.version = NVTX_VERSION; \
+        eventAttrib.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE; \
+        eventAttrib.colorType = NVTX_COLOR_ARGB; \
+        eventAttrib.color = colors[color_id]; \
+        eventAttrib.messageType = NVTX_MESSAGE_TYPE_ASCII; \
+        eventAttrib.message.ascii = name; \
+        nvtxRangePushEx(&eventAttrib); \
 } while(0)
 #define NVTX_POP() do { nvtxRangePop(); } while(0)
 #else
@@ -64,10 +64,10 @@
 //----
 
 enum gpu_msg_level {
-    GPU_MSG_DEBUG = 1,
-    GPU_MSG_INFO,
-    GPU_MSG_WARN,
-    GPU_MSG_ERROR
+        GPU_MSG_DEBUG = 1,
+        GPU_MSG_INFO,
+        GPU_MSG_WARN,
+        GPU_MSG_ERROR
 };
 
 
@@ -91,9 +91,9 @@ enum gpu_msg_level {
 #define gpu_err(FMT, ARGS...)  gpu_msg(GPU_MSG_ERROR, "ERR:  ", FMT, ##ARGS)
 
 #define gpu_fail_2(FMT, ARGS... ) do {                                  \
-                gpu_err(">>> test FAILED in %s at %s:%d\n" FMT, __FUNCTION__, __FILE__, __LINE__, ## ARGS); \
-                exit(EXIT_FAILURE);                                     \
-        } while(0)
+        gpu_err(">>> test FAILED in %s at %s:%d\n" FMT, __FUNCTION__, __FILE__, __LINE__, ## ARGS); \
+        exit(EXIT_FAILURE);                                     \
+} while(0)
 #define gpu_fail(FMT, ARGS...) gpu_fail_2(FMT, ##ARGS)
 
 //---
@@ -109,12 +109,12 @@ enum gpu_msg_level {
 
 
 #define __GDSCHECK(stmt, cond_str)					\
-	do {								\
-		int result = (stmt);                                    \
-		if (0 != result) {                                      \
-			const char *err_str = strerror(result);         \
-			gpu_fail("Assertion \"%s returned %s\" failed\n", cond_str, err_str); \
-		}							\
+        do {								\
+                int result = (stmt);                                    \
+                if (0 != result) {                                      \
+                        const char *err_str = strerror(result);         \
+                        gpu_fail("Assertion \"%s returned %s\" failed\n", cond_str, err_str); \
+                }							\
         } while (0)
 
 #define GDSCHECK(stmt) __GDSCHECK(stmt, #stmt)
@@ -122,14 +122,14 @@ enum gpu_msg_level {
 //----
 
 #define __CUCHECK(stmt, cond_str)					\
-	do {								\
-		CUresult result = (stmt);				\
-		if (CUDA_SUCCESS != result) {				\
-			const char *err_str = NULL;			\
-			cuGetErrorString(result, &err_str);		\
-			fprintf(stderr, "Assertion \"%s != cudaSuccess\" failed at %s:%d error=%d(%s)\n", cond_str, __FILE__, __LINE__, result, err_str); \
-			exit(EXIT_FAILURE);                             \
-		}							\
+        do {								\
+                CUresult result = (stmt);				\
+                if (CUDA_SUCCESS != result) {				\
+                        const char *err_str = NULL;			\
+                        cuGetErrorString(result, &err_str);		\
+                        fprintf(stderr, "Assertion \"%s != cudaSuccess\" failed at %s:%d error=%d(%s)\n", cond_str, __FILE__, __LINE__, result, err_str); \
+                        exit(EXIT_FAILURE);                             \
+                }							\
         } while (0)
 
 #define CUCHECK(stmt) __CUCHECK(stmt, #stmt)
@@ -137,12 +137,12 @@ enum gpu_msg_level {
 //----
 
 #define __CUDACHECK(stmt, cond_str)					\
-	do {								\
-		cudaError_t result = (stmt);				\
-		if (cudaSuccess != result) {				\
-			fprintf(stderr, "Assertion \"%s != cudaSuccess\" failed at %s:%d error=%d(%s)\n", cond_str, __FILE__, __LINE__, result, cudaGetErrorString(result)); \
-			exit(EXIT_FAILURE);				\
-		}							\
+        do {								\
+                cudaError_t result = (stmt);				\
+                if (cudaSuccess != result) {				\
+                        fprintf(stderr, "Assertion \"%s != cudaSuccess\" failed at %s:%d error=%d(%s)\n", cond_str, __FILE__, __LINE__, result, cudaGetErrorString(result)); \
+                        exit(EXIT_FAILURE);				\
+                }							\
         } while (0)
 
 #define CUDACHECK(stmt) __CUDACHECK(stmt, #stmt)

--- a/tests/gpu_kernels.cu
+++ b/tests/gpu_kernels.cu
@@ -19,7 +19,7 @@ int gpu_launch_void_kernel_on_stream(CUstream s)
 {
         const int nblocks = 1;
         const int nthreads = 1;
-	void_kernel<<<nblocks, nthreads, 0, s>>>();
+        void_kernel<<<nblocks, nthreads, 0, s>>>();
         CUDACHECK(cudaGetLastError());
         return 0;
 }
@@ -44,7 +44,7 @@ int gpu_launch_dummy_kernel(void)
         int p0 = 100;
         float p1 = 1.1f;
         float *p2 = NULL;
-	dummy_kernel<<<nblocks, nthreads, 0, gpu_stream>>>(p0, p1, p2);
+        dummy_kernel<<<nblocks, nthreads, 0, gpu_stream>>>(p0, p1, p2);
         CUDACHECK(cudaGetLastError());
         return 0;
 }
@@ -78,7 +78,7 @@ int gpu_launch_calc_kernel_on_stream(size_t size, CUstream s)
         // at least 1 thr block
         int nb = std::min(((n + nthreads - 1) / nthreads), nblocks);
         assert(nb >= 1);
-	calc_kernel<<<nb, nthreads, 0, s>>>(n, 1.0f, in, out);
+        calc_kernel<<<nb, nthreads, 0, s>>>(n, 1.0f, in, out);
         CUDACHECK(cudaGetLastError());
         return 0;
 }

--- a/tests/pingpong.c
+++ b/tests/pingpong.c
@@ -38,50 +38,50 @@
 
 enum ibv_mtu pp_mtu_to_enum(int mtu)
 {
-	switch (mtu) {
-	case 256:  return IBV_MTU_256;
-	case 512:  return IBV_MTU_512;
-	case 1024: return IBV_MTU_1024;
-	case 2048: return IBV_MTU_2048;
-	case 4096: return IBV_MTU_4096;
-	default:   return -1;
-	}
+        switch (mtu) {
+                case 256:  return IBV_MTU_256;
+                case 512:  return IBV_MTU_512;
+                case 1024: return IBV_MTU_1024;
+                case 2048: return IBV_MTU_2048;
+                case 4096: return IBV_MTU_4096;
+                default:   return -1;
+        }
 }
 
 uint16_t pp_get_local_lid(struct ibv_context *context, int port)
 {
-	struct ibv_port_attr attr;
+        struct ibv_port_attr attr;
 
-	if (ibv_query_port(context, port, &attr))
-		return 0;
+        if (ibv_query_port(context, port, &attr))
+                return 0;
 
-	return attr.lid;
+        return attr.lid;
 }
 
 int pp_get_port_info(struct ibv_context *context, int port,
-		     struct ibv_port_attr *attr)
+                struct ibv_port_attr *attr)
 {
-	return ibv_query_port(context, port, attr);
+        return ibv_query_port(context, port, attr);
 }
 
 void wire_gid_to_gid(const char *wgid, union ibv_gid *gid)
 {
-	char tmp[9];
-	uint32_t v32;
-	int i;
+        char tmp[9];
+        uint32_t v32;
+        int i;
 
-	for (tmp[8] = 0, i = 0; i < 4; ++i) {
-		memcpy(tmp, wgid + i * 8, 8);
-		sscanf(tmp, "%x", &v32);
-		*(uint32_t *)(&gid->raw[i * 4]) = ntohl(v32);
-	}
+        for (tmp[8] = 0, i = 0; i < 4; ++i) {
+                memcpy(tmp, wgid + i * 8, 8);
+                sscanf(tmp, "%x", &v32);
+                *(uint32_t *)(&gid->raw[i * 4]) = ntohl(v32);
+        }
 }
 
 void gid_to_wire_gid(const union ibv_gid *gid, char wgid[])
 {
-	int i;
+        int i;
 
-	for (i = 0; i < 4; ++i)
-		sprintf(&wgid[i * 8], "%08x",
-			htonl(*(uint32_t *)(gid->raw + i * 4)));
+        for (i = 0; i < 4; ++i)
+                sprintf(&wgid[i * 8], "%08x",
+                                htonl(*(uint32_t *)(gid->raw + i * 4)));
 }

--- a/tests/pingpong.h
+++ b/tests/pingpong.h
@@ -34,7 +34,6 @@
 #define IBV_PINGPONG_H
 
 #include <infiniband/verbs.h>
-#include <infiniband/verbs_exp.h>
 
 enum ibv_mtu pp_mtu_to_enum(int mtu);
 uint16_t pp_get_local_lid(struct ibv_context *context, int port);

--- a/tests/rstest.cpp
+++ b/tests/rstest.cpp
@@ -31,84 +31,84 @@
 using namespace std;
 
 std::ostream &operator <<(std::ostream &o, std::pair<const int, int> &r) {
-    o << "[" << r.first << "," << r.second << "]";
-    return o;
+        o << "[" << r.first << "," << r.second << "]";
+        return o;
 }
 
 std::ostream &operator << (std::ostream &o, RangeSet &rs) {
 #if __cplusplus <= 199711L // not C++-11, hopefully C++-98
-    for (RangeSet::iterator _s = rs.begin(); _s != rs.end(); ++_s) { Range s = *_s;
+        for (RangeSet::iterator _s = rs.begin(); _s != rs.end(); ++_s) { Range s = *_s;
 #else
-    for (auto s: rs) {
+        for (auto s: rs) {
 #endif
-        std::cout << s << std::endl;
-    }
-    return o;
+                std::cout << s << std::endl;
+        }
+        return o;
 }
 
 int main()
 {
-    RangeSet rs;
+        RangeSet rs;
 
-    Range r1(1,2);
-    Range r2(4,5);
-    Range r3(8,22);
+        Range r1(1,2);
+        Range r2(4,5);
+        Range r3(8,22);
 
-    rs.insert(r1);
-    rs.insert(r2);
-    rs.insert(r3);
+        rs.insert(r1);
+        rs.insert(r2);
+        rs.insert(r3);
 
-    cout << "rs contains:" << endl;
-    cout << rs;
-    cout << endl;
+        cout << "rs contains:" << endl;
+        cout << rs;
+        cout << endl;
 
-    { RangeSet::find_result res = rs.find(r1); Range r = *res.first; assert(r == r1); assert(res.second == RangeSet::fully_contained); }
-    
-    { RangeSet::find_result res = rs.find(r2); Range r = *res.first; assert(r == r2); assert(res.second == RangeSet::fully_contained); }
+        { RangeSet::find_result res = rs.find(r1); Range r = *res.first; assert(r == r1); assert(res.second == RangeSet::fully_contained); }
 
-    { 
-        RangeSet::find_result res = rs.find(r3); 
-        Range r = *res.first; 
-        if (r.second == RangeSet::not_found) {
-            assert(res.first == rs.end());
-            cout << "cannot find range " << r3 << endl; 
+        { RangeSet::find_result res = rs.find(r2); Range r = *res.first; assert(r == r2); assert(res.second == RangeSet::fully_contained); }
+
+        { 
+                RangeSet::find_result res = rs.find(r3); 
+                Range r = *res.first; 
+                if (r.second == RangeSet::not_found) {
+                        assert(res.first == rs.end());
+                        cout << "cannot find range " << r3 << endl; 
+                }
+                else {
+                        if (r != r3) cout << "ERROR: " << r3 << endl;
+                        if (res.second != RangeSet::fully_contained) cout << "ERROR: result " << res.second << endl;
+                }
         }
-        else {
-            if (r != r3) cout << "ERROR: " << r3 << endl;
-            if (res.second != RangeSet::fully_contained) cout << "ERROR: result " << res.second << endl;
+
+        { Range r(8,9); RangeSet::find_result res = rs.find(r); Range ro = *res.first; cout << r << " is contained in " << ro << endl; assert(res.second == RangeSet::fully_contained); }
+
+        { Range r(7,9); RangeSet::find_result res = rs.find(r); Range ro = *res.first; cout << r << " partially overlaps with " << ro << endl; assert(res.second == RangeSet::partial_overlap); }
+
+        {
+                Range r4(5,6);
+                cout << "range extension test" << endl;
+                cout << "adding " << r4 << endl;
+                RangeSet::insert_result res = rs.insert(r4);
+                cout << "res.first=" << *res.first << " res.second=" << res.second << endl;
+                assert(*res.first == Range(4,6));
+                assert(res.second);
         }
-    }
-    
-    { Range r(8,9); RangeSet::find_result res = rs.find(r); Range ro = *res.first; cout << r << " is contained in " << ro << endl; assert(res.second == RangeSet::fully_contained); }
 
-    { Range r(7,9); RangeSet::find_result res = rs.find(r); Range ro = *res.first; cout << r << " partially overlaps with " << ro << endl; assert(res.second == RangeSet::partial_overlap); }
+        cout << "rs contains:" << endl;
+        cout << rs;
+        cout << endl;
 
-    {
-        Range r4(5,6);
-        cout << "range extension test" << endl;
-        cout << "adding " << r4 << endl;
-        RangeSet::insert_result res = rs.insert(r4);
-        cout << "res.first=" << *res.first << " res.second=" << res.second << endl;
-        assert(*res.first == Range(4,6));
-        assert(res.second);
-    }
+        {
+                Range r5(5,9);
+                cout << "range extension test" << endl;
+                cout << "adding " << r5 << endl;
+                RangeSet::insert_result res = rs.insert(r5);
+                cout << "res.first=" << *res.first << " res.second=" << res.second << endl;
+                //assert(*res.first == Range(4,6));
+                //assert(res.second);
+        }
 
-    cout << "rs contains:" << endl;
-    cout << rs;
-    cout << endl;
-
-    {
-        Range r5(5,9);
-        cout << "range extension test" << endl;
-        cout << "adding " << r5 << endl;
-        RangeSet::insert_result res = rs.insert(r5);
-        cout << "res.first=" << *res.first << " res.second=" << res.second << endl;
-        //assert(*res.first == Range(4,6));
-        //assert(res.second);
-    }
-
-    cout << "rs contains:" << endl;
-    cout << rs;
-    cout << endl;
+        cout << "rs contains:" << endl;
+        cout << rs;
+        cout << endl;
 
 }

--- a/tests/task_queue_test.cpp
+++ b/tests/task_queue_test.cpp
@@ -38,8 +38,8 @@
 
 #if 0
 #define msg(FMT, ARGS...)   do {                           \
-                printf("%s() " FMT, __FUNCTION__ ,##ARGS); \
-        } while(0)
+        printf("%s() " FMT, __FUNCTION__ ,##ARGS); \
+} while(0)
 #else
 #define msg(FMT, ARGS...)   do { } while(0)
 #endif
@@ -81,7 +81,7 @@ struct slow_printer {
                         m_last_time = now;
                         m_store_time = false;
                 }
-        
+
                 if (now > m_last_time + std::chrono::milliseconds(1)) {
                         m_last_time = now;
                         msg("%p slow_printer i=%d\n", this, m_i);
@@ -106,7 +106,7 @@ main()
         {
                 task_queue wq;
                 int i = 0;
-                
+
                 slow_printer s;
                 wq.queue(std::bind(&slow_printer::run, &s));
 

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -61,7 +61,7 @@ static void gds_cpu_relax(void)
 static void gds_wmb(void) __attribute__((unused)) ;
 static void gds_wmb(void) 
 {
-	asm volatile("sync") ; 
+        asm volatile("sync") ; 
 }
 #else
 #error "platform not supported"


### PR DESCRIPTION
**This change:**
- addresses issue #79.
- moves exp-verbs-related data structure from public API to internal API.
- enables libgdsync to be compatible with ib-verbs (non-exp) from the perspective of users.
- does not remove exp-verbs from the internal implementation of libgdsync.
- fixes issue #83.
- aligns code in all files.

**Presubmit Testings:**
- locally on two nodes. each node had:
  - GPU: P40 or P100
  - NVIDIA driver version: 418
  - CUDA version: 10.1
  - CPU: Intel(R) Xeon(R) CPU E5-2687W v4
  - NIC: Mellanox Technologies MT27700 Family [ConnectX-4]
  - OFED: MLNX_OFED_SRC-4.5-1.0.1.0
  - OS: Ubuntu 18.04.1 LTS
- Tests: gds_kernel_latency, gds_kernel_loopback_latency