### PR TITLE
derive major,minor version from core.h

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -24,7 +24,7 @@ libgdsyncinclude_HEADERS = include/gdsync/core.h include/gdsync/device.cuh  incl
 
 src_libgdsync_la_CFLAGS = $(AM_CFLAGS)
 src_libgdsync_la_SOURCES = src/gdsync.cpp src/memmgr.cpp src/mem.cpp src/objs.cpp src/apis.cpp src/mlx5.cpp include/gdsync.h 
-src_libgdsync_la_LDFLAGS = -version-info 2:0:1
+src_libgdsync_la_LDFLAGS = -version-info @VERSION_INFO@
 
 noinst_HEADERS = src/mem.hpp src/memmgr.hpp src/objs.hpp src/rangeset.hpp src/utils.hpp src/archutils.h src/mlnxutils.h
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,10 +1,13 @@
 dnl Process this file with autoconf to produce a configure script.
 
-dnl m4_define([v_maj], [2])
-dnl m4_define([v_min], [2])
+dnl NOTE: the official suggestion for when to update the incremental version is:
+dnl "If the library source code has changed at all since the last update, then increment revision (‘c:r:a’ becomes ‘c:r+1:a’)."
+dnl from https://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html
+m4_define([incremental_ver], [0])
+
 m4_define([major_ver], m4_esyscmd([awk '/#define GDS_API_MAJOR_VERSION/ { print $3}' include/gdsync/core.h| tr -d '\n']))
 m4_define([minor_ver], m4_esyscmd([awk '/#define GDS_API_MINOR_VERSION/ { print $3}' include/gdsync/core.h| tr -d '\n']))
-m4_define([incremental_ver], [0])
+
 m4_define([project_version], [major_ver.minor_ver])
 m4_define([lt_cur], [m4_eval(major_ver + minor_ver)])
 m4_define([lt_rev], [incremental_ver])

--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,18 @@
 dnl Process this file with autoconf to produce a configure script.
 
+dnl m4_define([v_maj], [2])
+dnl m4_define([v_min], [2])
+m4_define([major_ver], m4_esyscmd([awk '/#define GDS_API_MAJOR_VERSION/ { print $3}' include/gdsync/core.h| tr -d '\n']))
+m4_define([minor_ver], m4_esyscmd([awk '/#define GDS_API_MINOR_VERSION/ { print $3}' include/gdsync/core.h| tr -d '\n']))
+m4_define([incremental_ver], [0])
+m4_define([project_version], [major_ver.minor_ver])
+m4_define([lt_cur], [m4_eval(major_ver + minor_ver)])
+m4_define([lt_rev], [incremental_ver])
+m4_define([lt_age], [minor_ver])
+m4_define([version_info], [lt_cur:lt_rev:lt_age])
+
 AC_PREREQ(2.57)
-AC_INIT(libgdsync, 2.2, gpudirect@github.com)
+AC_INIT(libgdsync, [project_version], gpudirect@github.com)
 AC_CONFIG_SRCDIR([src/mem.hpp])
 AC_CONFIG_AUX_DIR(config)
 AC_CONFIG_HEADER(config.h)
@@ -15,6 +26,8 @@ AC_PROG_LN_S
 AC_PROG_LIBTOOL
 
 LT_INIT
+
+AC_SUBST(VERSION_INFO, [version_info] )
 
 AX_CHECK_COMPILE_FLAG([-std=c++0x], [CXXFLAGS="$CXXFLAGS -std=c++0x"])
 AX_PTHREAD
@@ -185,6 +198,9 @@ dnl AC_CHECK_MEMBER([union CUstreamBatchMemOpParams_union.flushRemoteWrites],
 dnl   [AC_SUBST( HAS_CUDA_MEMOP_FLUSH_REMOTE_WRITES, 1 )],
 dnl   [AC_MSG_NOTICE([flushRemoteWrites is not defined])],
 dnl   [[#include <cuda.h>]])
+
+AC_MSG_NOTICE([project version: project_version ])
+AC_MSG_NOTICE([automake dynlib version info: version_info ])
 
 dnl Checks for CUDA >= 8.0
 AC_CHECK_LIB(cuda, cuStreamBatchMemOp, [],

--- a/include/gdsync/core.h
+++ b/include/gdsync/core.h
@@ -32,12 +32,12 @@
 #error "don't include directly this header, use gdsync.h always"
 #endif
 
-#define GDS_API_MAJOR_VERSION    2U
-#define GDS_API_MINOR_VERSION    2U
-#define GDS_API_VERSION          ((GDS_API_MAJOR_VERSION << 16) | GDS_API_MINOR_VERSION)
+#define GDS_API_MAJOR_VERSION    2
+#define GDS_API_MINOR_VERSION    2
+#define GDS_API_VERSION          (((unsigned)GDS_API_MAJOR_VERSION << 16) | (unsigned)GDS_API_MINOR_VERSION)
 #define GDS_API_VERSION_COMPATIBLE(v) \
-    ( ((((v) & 0xffff0000U) >> 16) == GDS_API_MAJOR_VERSION) &&   \
-      ((((v) & 0x0000ffffU) >> 0 ) >= GDS_API_MINOR_VERSION) )
+        ( ((((v) & 0xffff0000U) >> 16) == (unsigned)GDS_API_MAJOR_VERSION) && \
+          ((((v) & 0x0000ffffU) >> 0 ) >= (unsigned)GDS_API_MINOR_VERSION) )
 
 typedef enum gds_param {
     GDS_PARAM_VERSION,

--- a/libgdsync.spec.in
+++ b/libgdsync.spec.in
@@ -92,6 +92,8 @@ rm -rf $RPM_BUILD_ROOT
 %{_libdir}/libgdsync*.a
 
 %changelog
+* 2019-05-06  Davide Rossetti  <drossetti@nvidia.com>
+- libgdsync.spec.in: align AC_INIT version to GDS_API_*_VERSION
 * Wed Oct 5 2016 Davide Rossetti <drossetti@nvidia.com> - 1.0.0-1
 - New upstream release
 


### PR DESCRIPTION
And use that:
- for the dynlib soname
- for AC_INIT
- for libgdsync.spec

Note that incremental version (incremental_ver) is still an extra additional parameter, located in configure.ac, which must be manually incremented when appropriate (see comment therein).

fixes issue #81 